### PR TITLE
Add OkHttp and Ktor request executors + backend customization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ build/
 out/
 /run/
 *.iml
+/.kotlin

--- a/commons-httpclient/build.gradle
+++ b/commons-httpclient/build.gradle
@@ -14,6 +14,9 @@ base {
 kotlin {
     compilerOptions {
         jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+        // Emit metadata readable by older Kotlin consumers (Ktor 3.x is commonly built with Kotlin 2.1+)
+        languageVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2
+        apiVersion = org.jetbrains.kotlin.gradle.dsl.KotlinVersion.KOTLIN_2_2
     }
 }
 

--- a/commons-httpclient/build.gradle
+++ b/commons-httpclient/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id "project.defaults"
+    alias(libs.plugins.kotlinJvm)
 }
 
 base {
@@ -8,6 +9,12 @@ base {
     compileJava.sourceCompatibility = JavaVersion.VERSION_1_8
     compileTestJava.targetCompatibility = JavaVersion.VERSION_1_8
     compileTestJava.sourceCompatibility = JavaVersion.VERSION_1_8
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_1_8
+    }
 }
 
 sourceSets {
@@ -27,9 +34,13 @@ configurations {
 
 dependencies {
     compileOnly libs.reactorNetty
+    compileOnly libs.okhttp
+    compileOnly libs.kotlin.stdlib
+    compileOnly libs.ktor.client.core
     j11CompileOnly sourceSets.main.output
 
     testImplementation sourceSets.j11.output
+    testImplementation libs.ktor.client.cio
 }
 
 jar {

--- a/commons-httpclient/gradle.properties
+++ b/commons-httpclient/gradle.properties
@@ -1,1 +1,4 @@
 maven_name=httpclient
+
+# The Kotlin stdlib is only required for the optional Ktor executor and comes with the user provided Ktor dependency
+kotlin.stdlib.default.dependency=false

--- a/commons-httpclient/src/j11/java/net/lenni0451/commons/httpclient/executor/HttpClientExecutor.java
+++ b/commons-httpclient/src/j11/java/net/lenni0451/commons/httpclient/executor/HttpClientExecutor.java
@@ -12,6 +12,7 @@ import net.lenni0451.commons.httpclient.utils.URLWrapper;
 import net.lenni0451.commons.httpclient.utils.stream.CloseListenerInputStream;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
@@ -25,44 +26,93 @@ import java.util.Map;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
+import java.util.function.Consumer;
 
 /**
  * This executor uses the Java 11 HttpClient to execute requests.<br>
  * <b>Make sure you are running Java 11 or higher before loading this class!</b><br>
  * The safest way to access this class is by using Reflection.<br>
  * <br>
+ * The used {@link java.net.http.HttpClient} can be customized by passing a user provided client and/or a client customizer to the constructor.<br>
+ * Use it together with {@link HttpClient#HttpClient(java.util.function.Function)} (e.g. {@code new HttpClient(c -> new HttpClientExecutor(c, myJavaHttpClient))}).<br>
+ * <br>
  * Limitations:
  * <ul>
  *     <li>Only supports HTTP proxies</li>
  *     <li>Only supports HTTP/1.1 and HTTP/2</li>
+ *     <li>Client level settings (redirects, proxy, SSL, cookies, connect timeout) are not applied to user provided clients</li>
  * </ul>
  */
 public class HttpClientExecutor extends RequestExecutor {
 
+    @Nullable
+    private final java.net.http.HttpClient customHttpClient;
+    @Nullable
+    private final Consumer<java.net.http.HttpClient.Builder> clientCustomizer;
+
     public HttpClientExecutor(final HttpClient client) {
+        this(client, null, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param clientCustomizer A customizer that is applied to the {@link java.net.http.HttpClient.Builder} after the default configuration
+     */
+    public HttpClientExecutor(final HttpClient client, @Nullable final Consumer<java.net.http.HttpClient.Builder> clientCustomizer) {
+        this(client, null, clientCustomizer);
+    }
+
+    /**
+     * @param client           The http client
+     * @param customHttpClient A user provided client which is used for all requests.
+     *                         Its lifecycle is managed by the user and client level settings are not applied to it.
+     */
+    public HttpClientExecutor(final HttpClient client, @Nullable final java.net.http.HttpClient customHttpClient) {
+        this(client, customHttpClient, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param customHttpClient A user provided client which is used for all requests.
+     *                         Its lifecycle is managed by the user and client level settings are not applied to it.
+     * @param clientCustomizer A customizer that is applied to the {@link java.net.http.HttpClient.Builder} after the default configuration.
+     *                         It is ignored if a user provided client is used.
+     */
+    public HttpClientExecutor(final HttpClient client, @Nullable final java.net.http.HttpClient customHttpClient, @Nullable final Consumer<java.net.http.HttpClient.Builder> clientCustomizer) {
         super(client);
+        this.customHttpClient = customHttpClient;
+        this.clientCustomizer = clientCustomizer;
     }
 
     @Nonnull
     @Override
     public HttpResponse execute(@Nonnull final HttpRequest request) throws IOException {
+        if (this.customHttpClient != null) {
+            //The lifecycle of user provided clients is managed by the user
+            return this.executeRequest(this.customHttpClient, request, null);
+        }
         ExecutorService executor = Executors.newCachedThreadPool();
         java.net.http.HttpClient httpClient = null;
         boolean close = true;
         try {
             httpClient = this.buildClient(request, executor);
-            java.net.http.HttpRequest httpRequest = this.buildRequest(request);
-            if (request.isStreamedResponse()) {
-                java.net.http.HttpResponse<InputStream> response = this.executeRequest(httpClient, httpRequest, BodyHandlers.ofInputStream());
-                InputStream inputStream = new CloseListenerInputStream(response.body(), this.closeListener(executor, httpClient));
-                close = false; //Closing the http client would also close the input stream
-                return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), inputStream, response.headers().map());
-            } else {
-                java.net.http.HttpResponse<byte[]> response = this.executeRequest(httpClient, httpRequest, BodyHandlers.ofByteArray());
-                return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), response.body(), response.headers().map());
-            }
+            HttpResponse response = this.executeRequest(httpClient, request, this.closeListener(executor, httpClient));
+            if (request.isStreamedResponse()) close = false; //Closing the http client would also close the input stream
+            return response;
         } finally {
             if (close) this.closeListener(executor, httpClient).close();
+        }
+    }
+
+    private HttpResponse executeRequest(final java.net.http.HttpClient httpClient, final HttpRequest request, @Nullable final CloseListenerInputStream.CloseListener closeListener) throws IOException {
+        java.net.http.HttpRequest httpRequest = this.buildRequest(request);
+        if (request.isStreamedResponse()) {
+            java.net.http.HttpResponse<InputStream> response = this.send(httpClient, httpRequest, BodyHandlers.ofInputStream());
+            InputStream inputStream = closeListener == null ? response.body() : new CloseListenerInputStream(response.body(), closeListener);
+            return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), inputStream, response.headers().map());
+        } else {
+            java.net.http.HttpResponse<byte[]> response = this.send(httpClient, httpRequest, BodyHandlers.ofByteArray());
+            return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), response.body(), response.headers().map());
         }
     }
 
@@ -92,6 +142,7 @@ public class HttpClientExecutor extends RequestExecutor {
                 builder.authenticator(this.client.getProxyHandler().getProxyAuthenticator());
             }
         }
+        if (this.clientCustomizer != null) this.clientCustomizer.accept(builder);
         return builder.build();
     }
 
@@ -124,7 +175,7 @@ public class HttpClientExecutor extends RequestExecutor {
         return builder.build();
     }
 
-    private <T> java.net.http.HttpResponse<T> executeRequest(final java.net.http.HttpClient httpClient, final java.net.http.HttpRequest httpRequest, final java.net.http.HttpResponse.BodyHandler<T> bodyHandler) throws IOException {
+    private <T> java.net.http.HttpResponse<T> send(final java.net.http.HttpClient httpClient, final java.net.http.HttpRequest httpRequest, final java.net.http.HttpResponse.BodyHandler<T> bodyHandler) throws IOException {
         try {
             return httpClient.send(httpRequest, bodyHandler);
         } catch (InterruptedException e) {

--- a/commons-httpclient/src/j11/java/net/lenni0451/commons/httpclient/executor/HttpClientExecutor.java
+++ b/commons-httpclient/src/j11/java/net/lenni0451/commons/httpclient/executor/HttpClientExecutor.java
@@ -17,6 +17,7 @@ import java.io.Closeable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.CookieManager;
+import java.net.URL;
 import java.net.http.HttpClient.Redirect;
 import java.net.http.HttpRequest.BodyPublishers;
 import java.net.http.HttpResponse.BodyHandlers;
@@ -40,7 +41,7 @@ import java.util.function.Consumer;
  * <ul>
  *     <li>Only supports HTTP proxies</li>
  *     <li>Only supports HTTP/1.1 and HTTP/2</li>
- *     <li>Client level settings (redirects, proxy, SSL, cookies, connect timeout) are not applied to user provided clients</li>
+ *     <li>User provided clients only receive the request headers, body, cookies and read timeout; redirect, SSL, proxy and connect timeout settings (client and request level) are not applied to them</li>
  * </ul>
  */
 public class HttpClientExecutor extends RequestExecutor {
@@ -88,15 +89,16 @@ public class HttpClientExecutor extends RequestExecutor {
     @Override
     public HttpResponse execute(@Nonnull final HttpRequest request) throws IOException {
         if (this.customHttpClient != null) {
-            //The lifecycle of user provided clients is managed by the user
-            return this.executeRequest(this.customHttpClient, request, null);
+            //The lifecycle of user provided clients is managed by the user; cookies are still applied per request via headers
+            return this.executeRequest(this.customHttpClient, request, null, this.getCookieManager(request));
         }
         ExecutorService executor = Executors.newCachedThreadPool();
         java.net.http.HttpClient httpClient = null;
         boolean close = true;
         try {
             httpClient = this.buildClient(request, executor);
-            HttpResponse response = this.executeRequest(httpClient, request, this.closeListener(executor, httpClient));
+            //Cookies are handled by the client's cookie handler, so they are not applied per request here
+            HttpResponse response = this.executeRequest(httpClient, request, this.closeListener(executor, httpClient), null);
             if (request.isStreamedResponse()) close = false; //Closing the http client would also close the input stream
             return response;
         } finally {
@@ -104,15 +106,21 @@ public class HttpClientExecutor extends RequestExecutor {
         }
     }
 
-    private HttpResponse executeRequest(final java.net.http.HttpClient httpClient, final HttpRequest request, @Nullable final CloseListenerInputStream.CloseListener closeListener) throws IOException {
-        java.net.http.HttpRequest httpRequest = this.buildRequest(request);
+    private HttpResponse executeRequest(final java.net.http.HttpClient httpClient, final HttpRequest request, @Nullable final CloseListenerInputStream.CloseListener closeListener, @Nullable final CookieManager cookieManager) throws IOException {
+        java.net.http.HttpRequest httpRequest = this.buildRequest(request, cookieManager);
         if (request.isStreamedResponse()) {
             java.net.http.HttpResponse<InputStream> response = this.send(httpClient, httpRequest, BodyHandlers.ofInputStream());
+            URL url = new URLWrapper(response.uri()).toURL();
+            Map<String, List<String>> headers = response.headers().map();
+            this.updateCookies(cookieManager, url, headers);
             InputStream inputStream = closeListener == null ? response.body() : new CloseListenerInputStream(response.body(), closeListener);
-            return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), inputStream, response.headers().map());
+            return new HttpResponse(url, response.statusCode(), inputStream, headers);
         } else {
             java.net.http.HttpResponse<byte[]> response = this.send(httpClient, httpRequest, BodyHandlers.ofByteArray());
-            return new HttpResponse(new URLWrapper(response.uri()).toURL(), response.statusCode(), response.body(), response.headers().map());
+            URL url = new URLWrapper(response.uri()).toURL();
+            Map<String, List<String>> headers = response.headers().map();
+            this.updateCookies(cookieManager, url, headers);
+            return new HttpResponse(url, response.statusCode(), response.body(), headers);
         }
     }
 
@@ -146,7 +154,7 @@ public class HttpClientExecutor extends RequestExecutor {
         return builder.build();
     }
 
-    private java.net.http.HttpRequest buildRequest(final HttpRequest request) throws IOException {
+    private java.net.http.HttpRequest buildRequest(final HttpRequest request, @Nullable final CookieManager cookieManager) throws IOException {
         java.net.http.HttpRequest.Builder builder = java.net.http.HttpRequest.newBuilder();
         builder.uri(new URLWrapper(request.getURL()).toURI());
         builder.timeout(Duration.ofMillis(this.client.getReadTimeout()));
@@ -163,7 +171,8 @@ public class HttpClientExecutor extends RequestExecutor {
             bodyPublisher = BodyPublishers.noBody();
         }
         builder.method(request.getMethod(), bodyPublisher);
-        for (Map.Entry<String, List<String>> entry : this.getHeaders(request, null).entrySet()) {
+        //A non-null cookie manager is only passed for user provided clients (which have no cookie handler of their own)
+        for (Map.Entry<String, List<String>> entry : this.getHeaders(request, cookieManager).entrySet()) {
             if (entry.getKey().equalsIgnoreCase(HttpHeaders.CONTENT_LENGTH)) {
                 //Java 11 HttpClient does not allow manually setting the content length
                 continue;

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
@@ -63,7 +63,8 @@ public enum ExecutorType {
     ),
     /**
      * Use the Ktor executor.<br>
-     * Ktor (including a client engine) needs to be added as a dependency to your project.
+     * Ktor (including a client engine) needs to be added as a dependency to your project.<br>
+     * Note: only the presence of ktor-client-core is checked, a missing engine is only detected when the first request is executed.
      *
      * @see net.lenni0451.commons.httpclient.executor.extra.KtorExecutor
      */

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
@@ -45,6 +45,26 @@ public enum ExecutorType {
             "reactor.netty.http.client.HttpClient",
             "net.lenni0451.commons.httpclient.executor.extra.ReactorNettyExecutor"
     ),
+    /**
+     * Use the OkHttp executor.<br>
+     * OkHttp needs to be added as a dependency to your project.
+     *
+     * @see net.lenni0451.commons.httpclient.executor.extra.OkHttpExecutor
+     */
+    OK_HTTP(
+            "okhttp3.OkHttpClient",
+            "net.lenni0451.commons.httpclient.executor.extra.OkHttpExecutor"
+    ),
+    /**
+     * Use the Ktor executor.<br>
+     * Ktor (including a client engine) needs to be added as a dependency to your project.
+     *
+     * @see net.lenni0451.commons.httpclient.executor.extra.KtorExecutor
+     */
+    KTOR(
+            "io.ktor.client.HttpClient",
+            "net.lenni0451.commons.httpclient.executor.extra.KtorExecutor"
+    ),
     ;
 
     public static final ExecutorType DEFAULT = Stream.of(ExecutorType.values()).filter(type -> !type.equals(AUTO)).filter(ExecutorType::isAvailable).findFirst()

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/ExecutorType.java
@@ -8,6 +8,12 @@ import javax.annotation.Nullable;
 import java.lang.reflect.Constructor;
 import java.util.stream.Stream;
 
+/**
+ * The available executor types with their default configuration.<br>
+ * To customize an executor (e.g. use a user provided OkHttp/Ktor/reactor-netty/Java HttpClient instance or change engine parameters)
+ * instantiate it directly using {@link HttpClient#HttpClient(java.util.function.Function)}:<br>
+ * {@code new HttpClient(c -> new OkHttpExecutor(c, myOkHttpClient))}
+ */
 public enum ExecutorType {
 
     @Deprecated

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/URLConnectionExecutor.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/URLConnectionExecutor.java
@@ -20,10 +20,14 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Consumer;
 
 /**
  * Executor that uses {@link HttpURLConnection} to execute requests.<br>
  * This executor is available on all Java versions and is the default executor if no other executor is available.<br>
+ * <br>
+ * The used {@link HttpURLConnection} can be customized by passing a connection customizer to the constructor.<br>
+ * Use it together with {@link HttpClient#HttpClient(java.util.function.Function)} (e.g. {@code new HttpClient(c -> new URLConnectionExecutor(c, myCustomizer))}).<br>
  * <br>
  * Limitations:
  * <ul>
@@ -33,8 +37,20 @@ import java.util.Map;
  */
 public class URLConnectionExecutor extends RequestExecutor {
 
+    @Nullable
+    private final Consumer<HttpURLConnection> connectionCustomizer;
+
     public URLConnectionExecutor(final HttpClient client) {
+        this(client, null);
+    }
+
+    /**
+     * @param client               The http client
+     * @param connectionCustomizer A customizer that is applied to the {@link HttpURLConnection} after the default configuration and before connecting
+     */
+    public URLConnectionExecutor(final HttpClient client, @Nullable final Consumer<HttpURLConnection> connectionCustomizer) {
         super(client);
+        this.connectionCustomizer = connectionCustomizer;
     }
 
     @Nonnull
@@ -72,6 +88,7 @@ public class URLConnectionExecutor extends RequestExecutor {
             httpsConnection.setSSLSocketFactory(IgnoringTrustManager.makeIgnoringSSLContext().getSocketFactory());
         }
         this.setupConnection(connection, cookieManager, request);
+        if (this.connectionCustomizer != null) this.connectionCustomizer.accept(connection);
         connection.connect();
         return connection;
     }

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
@@ -1,0 +1,191 @@
+package net.lenni0451.commons.httpclient.executor.extra;
+
+import net.lenni0451.commons.httpclient.HttpClient;
+import net.lenni0451.commons.httpclient.HttpResponse;
+import net.lenni0451.commons.httpclient.content.HttpContent;
+import net.lenni0451.commons.httpclient.executor.RequestExecutor;
+import net.lenni0451.commons.httpclient.proxy.ProxyHandler;
+import net.lenni0451.commons.httpclient.proxy.ProxyType;
+import net.lenni0451.commons.httpclient.proxy.ThreadedProxyAuthenticator;
+import net.lenni0451.commons.httpclient.requests.HttpContentRequest;
+import net.lenni0451.commons.httpclient.requests.HttpRequest;
+import net.lenni0451.commons.httpclient.utils.IgnoringTrustManager;
+import net.lenni0451.commons.httpclient.utils.stream.CloseListenerInputStream;
+import okhttp3.Credentials;
+import okhttp3.MediaType;
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.RequestBody;
+import okhttp3.Response;
+import okhttp3.ResponseBody;
+import okio.BufferedSink;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.CookieManager;
+import java.net.URL;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Executor that uses OkHttp to execute requests.<br>
+ * Make sure to add the dependency to your project before using this executor.<br>
+ * <br>
+ * Limitations:
+ * <ul>
+ *     <li>GET and HEAD requests can not have a request body</li>
+ * </ul>
+ */
+public class OkHttpExecutor extends RequestExecutor {
+
+    private static final byte[] EMPTY_BODY = new byte[0];
+
+    public OkHttpExecutor(final HttpClient client) {
+        super(client);
+    }
+
+    @Nonnull
+    @Override
+    public HttpResponse execute(@Nonnull final HttpRequest request) throws IOException {
+        CookieManager cookieManager = this.getCookieManager(request);
+        ProxyHandler proxyHandler = this.client.getProxyHandler();
+        //HTTP proxy authentication is handled by OkHttp itself, SOCKS proxies authenticate through the global java.net.Authenticator
+        boolean useThreadedAuthenticator = proxyHandler.isProxySet() && proxyHandler.isAuthenticationSet() && !ProxyType.HTTP.equals(proxyHandler.getProxyType());
+        OkHttpClient httpClient = this.buildClient(request);
+        boolean close = true;
+        try {
+            if (useThreadedAuthenticator) ThreadedProxyAuthenticator.setAuthentication(proxyHandler.getUsername(), proxyHandler.getPassword());
+            Response response = httpClient.newCall(this.buildRequest(request, cookieManager)).execute();
+            try {
+                this.updateCookies(cookieManager, response);
+                URL url = response.request().url().url();
+                Map<String, List<String>> headers = response.headers().toMultimap();
+                ResponseBody body = response.body();
+                if (request.isStreamedResponse() && body != null) {
+                    InputStream inputStream = new CloseListenerInputStream(body.byteStream(), () -> {
+                        response.close();
+                        this.closeClient(httpClient);
+                    });
+                    close = false;
+                    return new HttpResponse(url, response.code(), inputStream, headers);
+                } else {
+                    return new HttpResponse(url, response.code(), body == null ? EMPTY_BODY : body.bytes(), headers);
+                }
+            } finally {
+                if (close) response.close();
+            }
+        } finally {
+            if (useThreadedAuthenticator) ThreadedProxyAuthenticator.clearAuthentication();
+            if (close) this.closeClient(httpClient);
+        }
+    }
+
+    private OkHttpClient buildClient(final HttpRequest request) throws IOException {
+        boolean followRedirects = this.isFollowRedirects(request);
+        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+                .connectTimeout(this.client.getConnectTimeout(), TimeUnit.MILLISECONDS)
+                .readTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
+                .writeTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
+                .followRedirects(followRedirects)
+                .followSslRedirects(followRedirects);
+        if (this.isIgnoreInvalidSSL(request)) {
+            builder.sslSocketFactory(IgnoringTrustManager.makeIgnoringSSLContext().getSocketFactory(), new IgnoringTrustManager());
+            builder.hostnameVerifier((hostname, session) -> true);
+        }
+        ProxyHandler proxyHandler = this.client.getProxyHandler();
+        if (proxyHandler.isProxySet()) {
+            builder.proxy(proxyHandler.toJavaProxy());
+            if (proxyHandler.isAuthenticationSet() && ProxyType.HTTP.equals(proxyHandler.getProxyType())) {
+                String credentials = Credentials.basic(proxyHandler.getUsername(), proxyHandler.getPassword());
+                builder.proxyAuthenticator((route, response) -> {
+                    if (response.request().header("Proxy-Authorization") != null) return null; //The credentials were already rejected
+                    return response.request().newBuilder().header("Proxy-Authorization", credentials).build();
+                });
+            }
+        }
+        return builder.build();
+    }
+
+    private Request buildRequest(final HttpRequest request, @Nullable final CookieManager cookieManager) throws IOException {
+        Request.Builder builder = new Request.Builder();
+        try {
+            builder.url(request.getURL());
+        } catch (IllegalArgumentException e) {
+            throw new IOException("Invalid request URL", e);
+        }
+        RequestBody body = null;
+        if (request instanceof HttpContentRequest && ((HttpContentRequest) request).hasContent()) {
+            body = this.toRequestBody(((HttpContentRequest) request).getContent(), request.isStreamedRequest());
+        } else if (this.requiresRequestBody(request.getMethod())) {
+            body = RequestBody.create(EMPTY_BODY, null);
+        }
+        builder.method(request.getMethod(), body);
+        this.setHeaders(this.getHeaders(request, cookieManager), builder::header, builder::addHeader);
+        return builder.build();
+    }
+
+    private RequestBody toRequestBody(final HttpContent content, final boolean streamed) throws IOException {
+        MediaType mediaType = MediaType.parse(content.getType().toString());
+        if (streamed) {
+            return new RequestBody() {
+                @Nullable
+                @Override
+                public MediaType contentType() {
+                    return mediaType;
+                }
+
+                @Override
+                public long contentLength() {
+                    return content.getLength();
+                }
+
+                @Override
+                public boolean isOneShot() {
+                    return !content.canBeStreamedMultipleTimes();
+                }
+
+                @Override
+                public void writeTo(@Nonnull final BufferedSink sink) throws IOException {
+                    content.transferTo(sink.outputStream());
+                }
+            };
+        } else {
+            return RequestBody.create(content.getAsBytes(), mediaType);
+        }
+    }
+
+    private boolean requiresRequestBody(final String method) {
+        //Methods that require a request body according to OkHttp
+        switch (method) {
+            case "POST":
+            case "PUT":
+            case "PATCH":
+            case "PROPPATCH":
+            case "REPORT":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void updateCookies(@Nullable final CookieManager cookieManager, final Response response) throws IOException {
+        if (cookieManager == null) return;
+        //Walk the redirect chain from oldest to newest to also store cookies set by intermediate responses
+        Deque<Response> responses = new ArrayDeque<>();
+        for (Response r = response; r != null; r = r.priorResponse()) responses.addFirst(r);
+        for (Response r : responses) {
+            this.updateCookies(cookieManager, r.request().url().url(), r.headers().toMultimap());
+        }
+    }
+
+    private void closeClient(final OkHttpClient httpClient) {
+        httpClient.dispatcher().executorService().shutdown();
+        httpClient.connectionPool().evictAll();
+    }
+
+}

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
@@ -31,10 +31,14 @@ import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
 /**
  * Executor that uses OkHttp to execute requests.<br>
  * Make sure to add the dependency to your project before using this executor.<br>
+ * <br>
+ * The used {@link OkHttpClient} can be customized by passing a base client and/or a client customizer to the constructor.<br>
+ * Use it together with {@link HttpClient#HttpClient(java.util.function.Function)} (e.g. {@code new HttpClient(c -> new OkHttpExecutor(c, myOkHttpClient))}).<br>
  * <br>
  * Limitations:
  * <ul>
@@ -45,8 +49,42 @@ public class OkHttpExecutor extends RequestExecutor {
 
     private static final byte[] EMPTY_BODY = new byte[0];
 
+    @Nullable
+    private final OkHttpClient baseClient;
+    @Nullable
+    private final Consumer<OkHttpClient.Builder> clientCustomizer;
+
     public OkHttpExecutor(final HttpClient client) {
+        this(client, null, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param clientCustomizer A customizer that is applied to the {@link OkHttpClient.Builder} after the default configuration
+     */
+    public OkHttpExecutor(final HttpClient client, @Nullable final Consumer<OkHttpClient.Builder> clientCustomizer) {
+        this(client, null, clientCustomizer);
+    }
+
+    /**
+     * @param client     The http client
+     * @param baseClient A user provided client which is used as the base for all requests (see {@link OkHttpClient#newBuilder()}).
+     *                   Its resources (dispatcher, connection pool, ...) are shared and will not be closed by this executor.
+     */
+    public OkHttpExecutor(final HttpClient client, @Nullable final OkHttpClient baseClient) {
+        this(client, baseClient, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param baseClient       A user provided client which is used as the base for all requests (see {@link OkHttpClient#newBuilder()}).
+     *                         Its resources (dispatcher, connection pool, ...) are shared and will not be closed by this executor.
+     * @param clientCustomizer A customizer that is applied to the {@link OkHttpClient.Builder} after the default configuration
+     */
+    public OkHttpExecutor(final HttpClient client, @Nullable final OkHttpClient baseClient, @Nullable final Consumer<OkHttpClient.Builder> clientCustomizer) {
         super(client);
+        this.baseClient = baseClient;
+        this.clientCustomizer = clientCustomizer;
     }
 
     @Nonnull
@@ -87,7 +125,7 @@ public class OkHttpExecutor extends RequestExecutor {
 
     private OkHttpClient buildClient(final HttpRequest request) throws IOException {
         boolean followRedirects = this.isFollowRedirects(request);
-        OkHttpClient.Builder builder = new OkHttpClient.Builder()
+        OkHttpClient.Builder builder = (this.baseClient != null ? this.baseClient.newBuilder() : new OkHttpClient.Builder())
                 .connectTimeout(this.client.getConnectTimeout(), TimeUnit.MILLISECONDS)
                 .readTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
                 .writeTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
@@ -108,6 +146,7 @@ public class OkHttpExecutor extends RequestExecutor {
                 });
             }
         }
+        if (this.clientCustomizer != null) this.clientCustomizer.accept(builder);
         return builder.build();
     }
 
@@ -184,6 +223,8 @@ public class OkHttpExecutor extends RequestExecutor {
     }
 
     private void closeClient(final OkHttpClient httpClient) {
+        //Clients derived from a user provided client share its resources which must not be closed
+        if (this.baseClient != null) return;
         httpClient.dispatcher().executorService().shutdown();
         httpClient.connectionPool().evictAll();
     }

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/OkHttpExecutor.java
@@ -2,6 +2,8 @@ package net.lenni0451.commons.httpclient.executor.extra;
 
 import net.lenni0451.commons.httpclient.HttpClient;
 import net.lenni0451.commons.httpclient.HttpResponse;
+import net.lenni0451.commons.httpclient.constants.HttpHeaders;
+import net.lenni0451.commons.httpclient.constants.RequestMethods;
 import net.lenni0451.commons.httpclient.content.HttpContent;
 import net.lenni0451.commons.httpclient.executor.RequestExecutor;
 import net.lenni0451.commons.httpclient.proxy.ProxyHandler;
@@ -11,7 +13,10 @@ import net.lenni0451.commons.httpclient.requests.HttpContentRequest;
 import net.lenni0451.commons.httpclient.requests.HttpRequest;
 import net.lenni0451.commons.httpclient.utils.IgnoringTrustManager;
 import net.lenni0451.commons.httpclient.utils.stream.CloseListenerInputStream;
+import okhttp3.Cookie;
+import okhttp3.CookieJar;
 import okhttp3.Credentials;
+import okhttp3.HttpUrl;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -22,13 +27,15 @@ import okio.BufferedSink;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
+import javax.net.ssl.SSLSocketFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.CookieManager;
 import java.net.URL;
-import java.util.ArrayDeque;
-import java.util.Deque;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
@@ -39,6 +46,8 @@ import java.util.function.Consumer;
  * <br>
  * The used {@link OkHttpClient} can be customized by passing a base client and/or a client customizer to the constructor.<br>
  * Use it together with {@link HttpClient#HttpClient(java.util.function.Function)} (e.g. {@code new HttpClient(c -> new OkHttpExecutor(c, myOkHttpClient))}).<br>
+ * A single backing client is reused for all requests (per-request settings are applied via {@link OkHttpClient#newBuilder()}), so the
+ * connection pool and dispatcher are shared and kept alive; they are never shut down by this executor.<br>
  * <br>
  * Limitations:
  * <ul>
@@ -48,11 +57,16 @@ import java.util.function.Consumer;
 public class OkHttpExecutor extends RequestExecutor {
 
     private static final byte[] EMPTY_BODY = new byte[0];
+    //The ignoring SSL factory and trust manager are stateless and can be shared across all requests
+    private static volatile SSLSocketFactory ignoringSocketFactory;
+    private static final IgnoringTrustManager IGNORING_TRUST_MANAGER = new IgnoringTrustManager();
 
     @Nullable
     private final OkHttpClient baseClient;
     @Nullable
     private final Consumer<OkHttpClient.Builder> clientCustomizer;
+    //Lazily created default client, reused for all requests so its connection pool and dispatcher are shared
+    private volatile OkHttpClient defaultClient;
 
     public OkHttpExecutor(final HttpClient client) {
         this(client, null, null);
@@ -94,21 +108,18 @@ public class OkHttpExecutor extends RequestExecutor {
         ProxyHandler proxyHandler = this.client.getProxyHandler();
         //HTTP proxy authentication is handled by OkHttp itself, SOCKS proxies authenticate through the global java.net.Authenticator
         boolean useThreadedAuthenticator = proxyHandler.isProxySet() && proxyHandler.isAuthenticationSet() && !ProxyType.HTTP.equals(proxyHandler.getProxyType());
-        OkHttpClient httpClient = this.buildClient(request);
+        OkHttpClient httpClient = this.buildClient(request, cookieManager);
         boolean close = true;
         try {
             if (useThreadedAuthenticator) ThreadedProxyAuthenticator.setAuthentication(proxyHandler.getUsername(), proxyHandler.getPassword());
-            Response response = httpClient.newCall(this.buildRequest(request, cookieManager)).execute();
+            Response response = httpClient.newCall(this.buildRequest(request)).execute();
             try {
-                this.updateCookies(cookieManager, response);
                 URL url = response.request().url().url();
                 Map<String, List<String>> headers = response.headers().toMultimap();
                 ResponseBody body = response.body();
                 if (request.isStreamedResponse() && body != null) {
-                    InputStream inputStream = new CloseListenerInputStream(body.byteStream(), () -> {
-                        response.close();
-                        this.closeClient(httpClient);
-                    });
+                    //Cookies are stored by the cookie jar; the connection is returned to the shared pool when the stream is closed
+                    InputStream inputStream = new CloseListenerInputStream(body.byteStream(), response::close);
                     close = false;
                     return new HttpResponse(url, response.code(), inputStream, headers);
                 } else {
@@ -119,20 +130,23 @@ public class OkHttpExecutor extends RequestExecutor {
             }
         } finally {
             if (useThreadedAuthenticator) ThreadedProxyAuthenticator.clearAuthentication();
-            if (close) this.closeClient(httpClient);
         }
     }
 
-    private OkHttpClient buildClient(final HttpRequest request) throws IOException {
+    private OkHttpClient buildClient(final HttpRequest request, @Nullable final CookieManager cookieManager) throws IOException {
         boolean followRedirects = this.isFollowRedirects(request);
-        OkHttpClient.Builder builder = (this.baseClient != null ? this.baseClient.newBuilder() : new OkHttpClient.Builder())
+        OkHttpClient.Builder builder = this.rootClient().newBuilder()
                 .connectTimeout(this.client.getConnectTimeout(), TimeUnit.MILLISECONDS)
                 .readTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
                 .writeTimeout(this.client.getReadTimeout(), TimeUnit.MILLISECONDS)
                 .followRedirects(followRedirects)
                 .followSslRedirects(followRedirects);
+        if (cookieManager != null) {
+            //A cookie jar participates in OkHttp's own redirect loop, so cookies are sent/stored per host and per hop
+            builder.cookieJar(new CookieManagerCookieJar(cookieManager));
+        }
         if (this.isIgnoreInvalidSSL(request)) {
-            builder.sslSocketFactory(IgnoringTrustManager.makeIgnoringSSLContext().getSocketFactory(), new IgnoringTrustManager());
+            builder.sslSocketFactory(ignoringSocketFactory(), IGNORING_TRUST_MANAGER);
             builder.hostnameVerifier((hostname, session) -> true);
         }
         ProxyHandler proxyHandler = this.client.getProxyHandler();
@@ -141,8 +155,8 @@ public class OkHttpExecutor extends RequestExecutor {
             if (proxyHandler.isAuthenticationSet() && ProxyType.HTTP.equals(proxyHandler.getProxyType())) {
                 String credentials = Credentials.basic(proxyHandler.getUsername(), proxyHandler.getPassword());
                 builder.proxyAuthenticator((route, response) -> {
-                    if (response.request().header("Proxy-Authorization") != null) return null; //The credentials were already rejected
-                    return response.request().newBuilder().header("Proxy-Authorization", credentials).build();
+                    if (response.request().header(HttpHeaders.PROXY_AUTHORIZATION) != null) return null; //The credentials were already rejected
+                    return response.request().newBuilder().header(HttpHeaders.PROXY_AUTHORIZATION, credentials).build();
                 });
             }
         }
@@ -150,26 +164,45 @@ public class OkHttpExecutor extends RequestExecutor {
         return builder.build();
     }
 
-    private Request buildRequest(final HttpRequest request, @Nullable final CookieManager cookieManager) throws IOException {
+    private OkHttpClient rootClient() {
+        if (this.baseClient != null) return this.baseClient;
+        if (this.defaultClient == null) {
+            synchronized (this) {
+                if (this.defaultClient == null) this.defaultClient = new OkHttpClient();
+            }
+        }
+        return this.defaultClient;
+    }
+
+    private Request buildRequest(final HttpRequest request) throws IOException {
         Request.Builder builder = new Request.Builder();
         try {
             builder.url(request.getURL());
         } catch (IllegalArgumentException e) {
             throw new IOException("Invalid request URL", e);
         }
+        //Cookies are handled by the cookie jar, so they are not injected as a header here
+        Map<String, List<String>> headers = this.getHeaders(request, null);
         RequestBody body = null;
         if (request instanceof HttpContentRequest && ((HttpContentRequest) request).hasContent()) {
-            body = this.toRequestBody(((HttpContentRequest) request).getContent(), request.isStreamedRequest());
+            //Honor a user provided Content-Type header for the body (OkHttp derives the sent Content-Type from the body)
+            String contentType = this.firstHeader(headers, HttpHeaders.CONTENT_TYPE);
+            body = this.toRequestBody(((HttpContentRequest) request).getContent(), request.isStreamedRequest(), contentType);
         } else if (this.requiresRequestBody(request.getMethod())) {
             body = RequestBody.create(EMPTY_BODY, null);
         }
-        builder.method(request.getMethod(), body);
-        this.setHeaders(this.getHeaders(request, cookieManager), builder::header, builder::addHeader);
+        try {
+            builder.method(request.getMethod(), body);
+            this.setHeaders(headers, builder::header, builder::addHeader);
+        } catch (IllegalArgumentException e) {
+            //OkHttp rejects e.g. bodies on GET/HEAD or non-ASCII header values with an unchecked exception
+            throw new IOException("Invalid request", e);
+        }
         return builder.build();
     }
 
-    private RequestBody toRequestBody(final HttpContent content, final boolean streamed) throws IOException {
-        MediaType mediaType = MediaType.parse(content.getType().toString());
+    private RequestBody toRequestBody(final HttpContent content, final boolean streamed, @Nullable final String contentType) throws IOException {
+        MediaType mediaType = MediaType.parse(contentType != null ? contentType : content.getType().toString());
         if (streamed) {
             return new RequestBody() {
                 @Nullable
@@ -199,11 +232,11 @@ public class OkHttpExecutor extends RequestExecutor {
     }
 
     private boolean requiresRequestBody(final String method) {
-        //Methods that require a request body according to OkHttp
+        //Methods that require a request body according to OkHttp (PROPPATCH/REPORT have no RequestMethods constant)
         switch (method) {
-            case "POST":
-            case "PUT":
-            case "PATCH":
+            case RequestMethods.POST:
+            case RequestMethods.PUT:
+            case RequestMethods.PATCH:
             case "PROPPATCH":
             case "REPORT":
                 return true;
@@ -212,21 +245,71 @@ public class OkHttpExecutor extends RequestExecutor {
         }
     }
 
-    private void updateCookies(@Nullable final CookieManager cookieManager, final Response response) throws IOException {
-        if (cookieManager == null) return;
-        //Walk the redirect chain from oldest to newest to also store cookies set by intermediate responses
-        Deque<Response> responses = new ArrayDeque<>();
-        for (Response r = response; r != null; r = r.priorResponse()) responses.addFirst(r);
-        for (Response r : responses) {
-            this.updateCookies(cookieManager, r.request().url().url(), r.headers().toMultimap());
-        }
+    @Nullable
+    private String firstHeader(final Map<String, List<String>> headers, final String name) {
+        List<String> values = headers.get(name.toLowerCase(Locale.ROOT));
+        return values == null || values.isEmpty() ? null : values.get(0);
     }
 
-    private void closeClient(final OkHttpClient httpClient) {
-        //Clients derived from a user provided client share its resources which must not be closed
-        if (this.baseClient != null) return;
-        httpClient.dispatcher().executorService().shutdown();
-        httpClient.connectionPool().evictAll();
+    private static SSLSocketFactory ignoringSocketFactory() throws IOException {
+        if (ignoringSocketFactory == null) {
+            synchronized (OkHttpExecutor.class) {
+                if (ignoringSocketFactory == null) ignoringSocketFactory = IgnoringTrustManager.makeIgnoringSSLContext().getSocketFactory();
+            }
+        }
+        return ignoringSocketFactory;
+    }
+
+
+    /**
+     * Bridges OkHttp's {@link CookieJar} to a {@link CookieManager} so cookies are sent and stored per host across redirects.
+     */
+    private static class CookieManagerCookieJar implements CookieJar {
+        private final CookieManager cookieManager;
+
+        private CookieManagerCookieJar(final CookieManager cookieManager) {
+            this.cookieManager = cookieManager;
+        }
+
+        @Nonnull
+        @Override
+        public List<Cookie> loadForRequest(@Nonnull final HttpUrl url) {
+            try {
+                Map<String, List<String>> headers = this.cookieManager.get(url.uri(), Collections.emptyMap());
+                List<Cookie> cookies = new ArrayList<>();
+                for (Map.Entry<String, List<String>> entry : headers.entrySet()) {
+                    if (!"Cookie".equalsIgnoreCase(entry.getKey())) continue;
+                    for (String header : entry.getValue()) {
+                        for (String pair : header.split(";")) {
+                            String trimmed = pair.trim();
+                            int idx = trimmed.indexOf('=');
+                            if (idx <= 0) continue;
+                            cookies.add(new Cookie.Builder()
+                                    .name(trimmed.substring(0, idx))
+                                    .value(trimmed.substring(idx + 1))
+                                    .hostOnlyDomain(url.host())
+                                    .path("/")
+                                    .build());
+                        }
+                    }
+                }
+                return cookies;
+            } catch (IOException e) {
+                return Collections.emptyList();
+            }
+        }
+
+        @Override
+        public void saveFromResponse(@Nonnull final HttpUrl url, @Nonnull final List<Cookie> cookies) {
+            if (cookies.isEmpty()) return;
+            List<String> setCookies = new ArrayList<>(cookies.size());
+            //Cookie.toString() renders a Set-Cookie compatible string which the CookieManager can parse back
+            for (Cookie cookie : cookies) setCookies.add(cookie.toString());
+            try {
+                this.cookieManager.put(url.uri(), Collections.singletonMap("Set-Cookie", setCookies));
+            } catch (IOException ignored) {
+            }
+        }
     }
 
 }

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/ReactorNettyExecutor.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/executor/extra/ReactorNettyExecutor.java
@@ -26,6 +26,7 @@ import reactor.netty.tcp.SslProvider;
 import reactor.netty.transport.ProxyProvider;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UncheckedIOException;
@@ -37,19 +38,54 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 import java.util.stream.Stream;
 
 /**
  * Executor that uses reactor-netty to execute requests.<br>
  * Make sure to add the dependency to your project before using this executor.<br>
  * <br>
+ * The used {@link reactor.netty.http.client.HttpClient} can be customized by passing a base client and/or a client customizer to the constructor.<br>
+ * Use it together with {@link HttpClient#HttpClient(java.util.function.Function)} (e.g. {@code new HttpClient(c -> new ReactorNettyExecutor(c, myReactorClient))}).<br>
  */
 public class ReactorNettyExecutor extends RequestExecutor {
 
     private static final byte[] EMPTY_BODY = new byte[0];
 
+    @Nullable
+    private final reactor.netty.http.client.HttpClient baseClient;
+    @Nullable
+    private final UnaryOperator<reactor.netty.http.client.HttpClient> clientCustomizer;
+
     public ReactorNettyExecutor(final HttpClient client) {
+        this(client, null, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param clientCustomizer A customizer that is applied to the {@link reactor.netty.http.client.HttpClient} after the default configuration
+     */
+    public ReactorNettyExecutor(final HttpClient client, @Nullable final UnaryOperator<reactor.netty.http.client.HttpClient> clientCustomizer) {
+        this(client, null, clientCustomizer);
+    }
+
+    /**
+     * @param client     The http client
+     * @param baseClient A user provided client which is used as the base for all requests instead of {@link reactor.netty.http.client.HttpClient#create()}
+     */
+    public ReactorNettyExecutor(final HttpClient client, @Nullable final reactor.netty.http.client.HttpClient baseClient) {
+        this(client, baseClient, null);
+    }
+
+    /**
+     * @param client           The http client
+     * @param baseClient       A user provided client which is used as the base for all requests instead of {@link reactor.netty.http.client.HttpClient#create()}
+     * @param clientCustomizer A customizer that is applied to the {@link reactor.netty.http.client.HttpClient} after the default configuration
+     */
+    public ReactorNettyExecutor(final HttpClient client, @Nullable final reactor.netty.http.client.HttpClient baseClient, @Nullable final UnaryOperator<reactor.netty.http.client.HttpClient> clientCustomizer) {
         super(client);
+        this.baseClient = baseClient;
+        this.clientCustomizer = clientCustomizer;
     }
 
     @Nonnull
@@ -147,7 +183,7 @@ public class ReactorNettyExecutor extends RequestExecutor {
 
     private reactor.netty.http.client.HttpClient buildClient(final HttpRequest request, final CookieManager cookieManager) throws IOException {
         Map<String, List<String>> requestHeaders = this.getHeaders(request, cookieManager);
-        reactor.netty.http.client.HttpClient httpClient = reactor.netty.http.client.HttpClient.create()
+        reactor.netty.http.client.HttpClient httpClient = (this.baseClient != null ? this.baseClient : reactor.netty.http.client.HttpClient.create())
                 .responseTimeout(Duration.ofMillis(this.client.getReadTimeout()))
                 .followRedirect(this.isFollowRedirects(request))
                 .headers(headers -> this.setHeaders(requestHeaders, headers::set, headers::add));
@@ -176,6 +212,7 @@ public class ReactorNettyExecutor extends RequestExecutor {
                 if (proxyHandler.getPassword() != null) builder.password(s -> proxyHandler.getPassword());
             });
         }
+        if (this.clientCustomizer != null) httpClient = this.clientCustomizer.apply(httpClient);
         return httpClient;
     }
 

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/model/ContentType.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/model/ContentType.java
@@ -2,7 +2,6 @@ package net.lenni0451.commons.httpclient.model;
 
 import javax.annotation.Nullable;
 import java.nio.charset.Charset;
-import java.nio.charset.UnsupportedCharsetException;
 import java.util.Locale;
 import java.util.Objects;
 import java.util.Optional;
@@ -25,14 +24,22 @@ public class ContentType {
             String part = parts[i].trim();
             if (part.startsWith("charset=")) {
                 try {
-                    charset = Charset.forName(part.substring(8));
-                } catch (UnsupportedCharsetException ignored) {
+                    //IllegalArgumentException also covers IllegalCharsetNameException for malformed (e.g. quoted) charset values
+                    charset = Charset.forName(stripQuotes(part.substring(8)));
+                } catch (IllegalArgumentException ignored) {
                 }
             } else if (part.startsWith("boundary=")) {
                 boundary = part.substring(9);
             }
         }
         return new ContentType(type, charset, boundary);
+    }
+
+    private static String stripQuotes(final String value) {
+        if (value.length() >= 2 && value.charAt(0) == '"' && value.charAt(value.length() - 1) == '"') {
+            return value.substring(1, value.length() - 1);
+        }
+        return value;
     }
 
 

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/utils/IgnoringTrustManager.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/utils/IgnoringTrustManager.java
@@ -48,7 +48,8 @@ public class IgnoringTrustManager extends X509ExtendedTrustManager {
 
     @Override
     public X509Certificate[] getAcceptedIssuers() {
-        return null;
+        //The X509TrustManager contract requires a non-null array and some libraries (e.g. OkHttp) fail on null
+        return new X509Certificate[0];
     }
 
 }

--- a/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/utils/stream/CloseListenerInputStream.java
+++ b/commons-httpclient/src/main/java/net/lenni0451/commons/httpclient/utils/stream/CloseListenerInputStream.java
@@ -41,8 +41,12 @@ public class CloseListenerInputStream extends InputStream {
 
     @Override
     public void close() throws IOException {
-        this.inputStream.close();
-        this.closeListener.close();
+        //Always run the close listener, even if closing the wrapped stream fails, so backend resources are released
+        try {
+            this.inputStream.close();
+        } finally {
+            this.closeListener.close();
+        }
     }
 
 

--- a/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
+++ b/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
@@ -1,0 +1,167 @@
+package net.lenni0451.commons.httpclient.executor.extra
+
+import io.ktor.client.call.body
+import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.request.*
+import io.ktor.client.statement.*
+import io.ktor.http.ContentType
+import io.ktor.http.Headers
+import io.ktor.http.HttpHeaders
+import io.ktor.http.HttpMethod
+import io.ktor.http.content.ByteArrayContent
+import io.ktor.http.content.OutgoingContent
+import io.ktor.utils.io.*
+import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.withContext
+import net.lenni0451.commons.httpclient.HttpClient
+import net.lenni0451.commons.httpclient.HttpResponse
+import net.lenni0451.commons.httpclient.content.HttpContent
+import net.lenni0451.commons.httpclient.executor.RequestExecutor
+import net.lenni0451.commons.httpclient.proxy.ProxyType
+import net.lenni0451.commons.httpclient.proxy.ThreadedProxyAuthenticator
+import net.lenni0451.commons.httpclient.requests.HttpContentRequest
+import net.lenni0451.commons.httpclient.requests.HttpRequest
+import net.lenni0451.commons.httpclient.utils.URLWrapper
+import net.lenni0451.commons.httpclient.utils.stream.CloseListenerInputStream
+import java.io.IOException
+import java.net.CookieManager
+import java.nio.charset.StandardCharsets
+import java.util.Base64
+import io.ktor.client.HttpClient as KtorClient
+
+/**
+ * Executor that uses Ktor to execute requests.<br>
+ * Make sure to add the dependency (including a client engine) to your project before using this executor.<br>
+ * The engine is discovered from the classpath by Ktor itself.<br>
+ * <br>
+ * Limitations:
+ * <ul>
+ *     <li>Ignoring invalid SSL certificates is engine specific and therefore not supported</li>
+ *     <li>Proxy support depends on the used engine</li>
+ * </ul>
+ */
+class KtorExecutor(client: HttpClient) : RequestExecutor(client) {
+
+    override fun execute(request: HttpRequest): HttpResponse {
+        if (this.isIgnoreInvalidSSL(request)) {
+            throw UnsupportedOperationException("Ignoring invalid SSL certificates is engine specific and not supported by the Ktor executor")
+        }
+        val cookieManager = this.getCookieManager(request)
+        val proxyHandler = this.client.proxyHandler
+        //HTTP proxy authentication is sent preemptively, SOCKS proxies authenticate through the global java.net.Authenticator
+        val useThreadedAuthenticator = proxyHandler.isProxySet && proxyHandler.isAuthenticationSet && ProxyType.HTTP != proxyHandler.proxyType
+        val httpClient = this.buildClient(request)
+        var close = true
+        try {
+            if (useThreadedAuthenticator) ThreadedProxyAuthenticator.setAuthentication(proxyHandler.username, proxyHandler.password)
+            val requestBuilder = this.buildRequest(request, cookieManager)
+            return runBlocking {
+                val response = httpClient.request(requestBuilder)
+                val url = URLWrapper.ofURL(response.request.url.toString()).toURL()
+                val headers = convertHeaders(response.headers)
+                updateCookies(cookieManager, url, headers)
+                if (request.isStreamedResponse) {
+                    val inputStream = CloseListenerInputStream(response.bodyAsChannel().toInputStream()) { httpClient.close() }
+                    close = false
+                    HttpResponse(url, response.status.value, inputStream, headers)
+                } else {
+                    HttpResponse(url, response.status.value, response.body<ByteArray>(), headers)
+                }
+            }
+        } catch (e: IOException) {
+            throw e
+        } catch (e: InterruptedException) {
+            throw e
+        } catch (t: Throwable) {
+            throw this.unwrap(t)
+        } finally {
+            if (useThreadedAuthenticator) ThreadedProxyAuthenticator.clearAuthentication()
+            if (close) httpClient.close()
+        }
+    }
+
+    private fun buildClient(request: HttpRequest): KtorClient {
+        val follow = this.isFollowRedirects(request)
+        val connectTimeout = this.client.connectTimeout.toLong()
+        val readTimeout = this.client.readTimeout.toLong()
+        val proxyHandler = this.client.proxyHandler
+        return KtorClient {
+            followRedirects = follow
+            expectSuccess = false
+            install(HttpTimeout) {
+                connectTimeoutMillis = connectTimeout
+                socketTimeoutMillis = readTimeout
+            }
+            if (proxyHandler.isProxySet) {
+                engine {
+                    proxy = proxyHandler.toJavaProxy()
+                }
+            }
+        }
+    }
+
+    private fun buildRequest(request: HttpRequest, cookieManager: CookieManager?): HttpRequestBuilder {
+        val builder = HttpRequestBuilder()
+        builder.method = HttpMethod.parse(request.method)
+        builder.url(request.getURL().toString())
+        if (request is HttpContentRequest && request.hasContent()) {
+            builder.setBody(this.toRequestBody(request.content!!, request.isStreamedRequest))
+        }
+        //Content headers are excluded because Ktor does not allow setting them directly, they are taken from the request body instead
+        this.setHeaders(
+            this.getHeaders(request, cookieManager, false),
+            { name, value -> builder.headers[name] = value },
+            { name, value -> builder.headers.append(name, value) }
+        )
+        val proxyHandler = this.client.proxyHandler
+        if (proxyHandler.isProxySet && proxyHandler.isAuthenticationSet && ProxyType.HTTP == proxyHandler.proxyType) {
+            //Ktor has no built-in support for proxy authentication, sending the header preemptively works for HTTP proxies
+            val credentials = Base64.getEncoder().encodeToString("${proxyHandler.username}:${proxyHandler.password}".toByteArray(StandardCharsets.ISO_8859_1))
+            builder.headers[HttpHeaders.ProxyAuthorization] = "Basic $credentials"
+        }
+        return builder
+    }
+
+    private fun toRequestBody(content: HttpContent, streamed: Boolean): OutgoingContent {
+        val mediaType = ContentType.parse(content.type.toString())
+        return if (streamed) {
+            object : OutgoingContent.WriteChannelContent() {
+                override val contentType: ContentType get() = mediaType
+                override val contentLength: Long? get() = if (content.length >= 0) content.length.toLong() else null
+
+                override suspend fun writeTo(channel: ByteWriteChannel) {
+                    withContext(Dispatchers.IO) {
+                        content.getAsStream().use { inputStream ->
+                            val buffer = ByteArray(maxOf(1, content.bufferSize))
+                            while (true) {
+                                val read = inputStream.read(buffer)
+                                if (read < 0) break
+                                channel.writeFully(buffer, 0, read)
+                            }
+                        }
+                    }
+                }
+            }
+        } else {
+            ByteArrayContent(content.getAsBytes(), mediaType)
+        }
+    }
+
+    private fun convertHeaders(headers: Headers): Map<String, List<String>> {
+        val map = HashMap<String, MutableList<String>>()
+        headers.forEach { name, values -> map.getOrPut(name) { ArrayList() }.addAll(values) }
+        return map
+    }
+
+    private fun unwrap(t: Throwable): IOException {
+        var cause: Throwable? = t
+        while (cause != null) {
+            if (cause is IOException) return cause
+            cause = cause.cause
+        }
+        return IOException("Failed to execute request", t)
+    }
+
+}

--- a/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
+++ b/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
@@ -1,6 +1,8 @@
 package net.lenni0451.commons.httpclient.executor.extra
 
+import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
+import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpTimeout
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
@@ -34,15 +36,30 @@ import io.ktor.client.HttpClient as KtorClient
 /**
  * Executor that uses Ktor to execute requests.<br>
  * Make sure to add the dependency (including a client engine) to your project before using this executor.<br>
- * The engine is discovered from the classpath by Ktor itself.<br>
+ * By default the engine is discovered from the classpath by Ktor itself.<br>
+ * <br>
+ * The used Ktor client can be customized by passing an engine factory, a user provided client and/or a config block to the constructor.<br>
+ * Use it together with [HttpClient(Function)][HttpClient] (e.g. `HttpClient { KtorExecutor(it, engineFactory = CIO) }`).<br>
  * <br>
  * Limitations:
  * <ul>
  *     <li>Ignoring invalid SSL certificates is engine specific and therefore not supported</li>
  *     <li>Proxy support depends on the used engine</li>
+ *     <li>Engine configuration (e.g. the proxy) is not applied to user provided clients</li>
  * </ul>
+ *
+ * @param client        The http client
+ * @param engineFactory The engine factory to use instead of the classpath discovery
+ * @param baseClient    A user provided client which is used as the base for all requests (see [io.ktor.client.HttpClient.config]).
+ *                      It takes precedence over the engine factory. Its engine is shared and will not be closed by this executor.
+ * @param clientConfig  A config block that is applied to the client config after the default configuration
  */
-class KtorExecutor(client: HttpClient) : RequestExecutor(client) {
+class KtorExecutor @JvmOverloads constructor(
+    client: HttpClient,
+    private val engineFactory: HttpClientEngineFactory<*>? = null,
+    private val baseClient: KtorClient? = null,
+    private val clientConfig: (HttpClientConfig<*>.() -> Unit)? = null,
+) : RequestExecutor(client) {
 
     override fun execute(request: HttpRequest): HttpResponse {
         if (this.isIgnoreInvalidSSL(request)) {
@@ -87,7 +104,8 @@ class KtorExecutor(client: HttpClient) : RequestExecutor(client) {
         val connectTimeout = this.client.connectTimeout.toLong()
         val readTimeout = this.client.readTimeout.toLong()
         val proxyHandler = this.client.proxyHandler
-        return KtorClient {
+        val clientConfig = this.clientConfig
+        val configure: HttpClientConfig<*>.() -> Unit = {
             followRedirects = follow
             expectSuccess = false
             install(HttpTimeout) {
@@ -95,10 +113,17 @@ class KtorExecutor(client: HttpClient) : RequestExecutor(client) {
                 socketTimeoutMillis = readTimeout
             }
             if (proxyHandler.isProxySet) {
+                //The engine configuration is ignored by Ktor if a user provided client is used
                 engine {
                     proxy = proxyHandler.toJavaProxy()
                 }
             }
+            clientConfig?.invoke(this)
+        }
+        return when {
+            this.baseClient != null -> this.baseClient.config(configure)
+            this.engineFactory != null -> KtorClient(this.engineFactory, configure)
+            else -> KtorClient(configure)
         }
     }
 

--- a/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
+++ b/commons-httpclient/src/main/kotlin/net/lenni0451/commons/httpclient/executor/extra/KtorExecutor.kt
@@ -4,21 +4,34 @@ import io.ktor.client.HttpClientConfig
 import io.ktor.client.call.body
 import io.ktor.client.engine.HttpClientEngineFactory
 import io.ktor.client.plugins.HttpTimeout
+import io.ktor.client.plugins.HttpTimeoutConfig
+import io.ktor.client.plugins.cookies.CookiesStorage
+import io.ktor.client.plugins.cookies.HttpCookies
 import io.ktor.client.request.*
 import io.ktor.client.statement.*
 import io.ktor.http.ContentType
+import io.ktor.http.Cookie
+import io.ktor.http.CookieEncoding
 import io.ktor.http.Headers
 import io.ktor.http.HttpHeaders
 import io.ktor.http.HttpMethod
+import io.ktor.http.Url
 import io.ktor.http.content.ByteArrayContent
 import io.ktor.http.content.OutgoingContent
+import io.ktor.http.renderSetCookieHeader
+import io.ktor.util.toMap
 import io.ktor.utils.io.*
 import io.ktor.utils.io.jvm.javaio.toInputStream
+import kotlinx.coroutines.CompletableDeferred
+import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.withContext
 import net.lenni0451.commons.httpclient.HttpClient
 import net.lenni0451.commons.httpclient.HttpResponse
+import net.lenni0451.commons.httpclient.constants.HttpHeaders as CommonsHttpHeaders
 import net.lenni0451.commons.httpclient.content.HttpContent
 import net.lenni0451.commons.httpclient.executor.RequestExecutor
 import net.lenni0451.commons.httpclient.proxy.ProxyType
@@ -28,15 +41,20 @@ import net.lenni0451.commons.httpclient.requests.HttpRequest
 import net.lenni0451.commons.httpclient.utils.URLWrapper
 import net.lenni0451.commons.httpclient.utils.stream.CloseListenerInputStream
 import java.io.IOException
+import java.io.InputStream
+import java.io.UncheckedIOException
 import java.net.CookieManager
-import java.nio.charset.StandardCharsets
+import java.net.URI
+import java.net.URL
 import java.util.Base64
+import java.util.concurrent.SynchronousQueue
 import io.ktor.client.HttpClient as KtorClient
 
 /**
  * Executor that uses Ktor to execute requests.<br>
  * Make sure to add the dependency (including a client engine) to your project before using this executor.<br>
- * By default the engine is discovered from the classpath by Ktor itself.<br>
+ * By default the engine is discovered from the classpath by Ktor itself; there is no way to detect a missing engine
+ * up front, so requests fail with an {@link IOException} if no engine is available.<br>
  * <br>
  * The used Ktor client can be customized by passing an engine factory, a user provided client and/or a config block to the constructor.<br>
  * Use it together with [HttpClient(Function)][HttpClient] (e.g. `HttpClient { KtorExecutor(it, engineFactory = CIO) }`).<br>
@@ -44,8 +62,9 @@ import io.ktor.client.HttpClient as KtorClient
  * Limitations:
  * <ul>
  *     <li>Ignoring invalid SSL certificates is engine specific and therefore not supported</li>
- *     <li>Proxy support depends on the used engine</li>
- *     <li>Engine configuration (e.g. the proxy) is not applied to user provided clients</li>
+ *     <li>Proxy support depends on the used engine; a proxy can not be applied to a user provided client (an exception is thrown)</li>
+ *     <li>The read timeout is mapped to the socket timeout, which some engines (e.g. ktor-client-java) do not honor</li>
+ *     <li>SOCKS proxy authentication may not work depending on the engine, as it authenticates on the calling thread</li>
  * </ul>
  *
  * @param client        The http client
@@ -65,46 +84,78 @@ class KtorExecutor @JvmOverloads constructor(
         if (this.isIgnoreInvalidSSL(request)) {
             throw UnsupportedOperationException("Ignoring invalid SSL certificates is engine specific and not supported by the Ktor executor")
         }
-        val cookieManager = this.getCookieManager(request)
         val proxyHandler = this.client.proxyHandler
+        if (proxyHandler.isProxySet && this.baseClient != null) {
+            //Ktor ignores the engine configuration of user provided clients, so the proxy would be silently bypassed
+            throw UnsupportedOperationException("A proxy can not be applied to a user provided Ktor client")
+        }
+        val cookieManager = this.getCookieManager(request)
         //HTTP proxy authentication is sent preemptively, SOCKS proxies authenticate through the global java.net.Authenticator
         val useThreadedAuthenticator = proxyHandler.isProxySet && proxyHandler.isAuthenticationSet && ProxyType.HTTP != proxyHandler.proxyType
-        val httpClient = this.buildClient(request)
+        var httpClient: KtorClient? = null
         var close = true
         try {
             if (useThreadedAuthenticator) ThreadedProxyAuthenticator.setAuthentication(proxyHandler.username, proxyHandler.password)
-            val requestBuilder = this.buildRequest(request, cookieManager)
-            return runBlocking {
-                val response = httpClient.request(requestBuilder)
-                val url = URLWrapper.ofURL(response.request.url.toString()).toURL()
-                val headers = convertHeaders(response.headers)
-                updateCookies(cookieManager, url, headers)
-                if (request.isStreamedResponse) {
-                    val inputStream = CloseListenerInputStream(response.bodyAsChannel().toInputStream()) { httpClient.close() }
-                    close = false
-                    HttpResponse(url, response.status.value, inputStream, headers)
-                } else {
-                    HttpResponse(url, response.status.value, response.body<ByteArray>(), headers)
-                }
+            httpClient = this.buildClient(request, cookieManager)
+            val requestBuilder = this.buildRequest(request)
+            val client = httpClient
+            if (request.isStreamedResponse) {
+                val response = this.executeStreamed(client, requestBuilder)
+                close = false //The streaming coroutine owns the client and closes it when the response stream is closed
+                return response
             }
-        } catch (e: IOException) {
-            throw e
+            return runBlocking {
+                val response = client.request(requestBuilder)
+                val url = URLWrapper.ofURL(response.request.url.toString()).toURL()
+                HttpResponse(url, response.status.value, response.body<ByteArray>(), response.headers.toMap())
+            }
         } catch (e: InterruptedException) {
             throw e
         } catch (t: Throwable) {
             throw this.unwrap(t)
         } finally {
             if (useThreadedAuthenticator) ThreadedProxyAuthenticator.clearAuthentication()
-            if (close) httpClient.close()
+            if (close) httpClient?.close()
         }
     }
 
-    private fun buildClient(request: HttpRequest): KtorClient {
+    private fun executeStreamed(httpClient: KtorClient, requestBuilder: HttpRequestBuilder): HttpResponse {
+        //Ktor's high level request() buffers the whole body in memory, so a kept-alive coroutine is used to stream incrementally
+        val handoff = SynchronousQueue<Any>()
+        val closed = CompletableDeferred<Unit>()
+        val scope = CoroutineScope(Dispatchers.IO)
+        scope.launch {
+            try {
+                httpClient.prepareRequest(requestBuilder).execute { response ->
+                    val url = URLWrapper.ofURL(response.request.url.toString()).toURL()
+                    val meta = StreamedResponse(url, response.status.value, response.headers.toMap(), response.bodyAsChannel().toInputStream())
+                    handoff.put(meta)
+                    //Keep the response (and connection) open until the caller closes the returned stream
+                    closed.await()
+                }
+            } catch (t: Throwable) {
+                //Only reaches a waiting caller if the response metadata was not handed off yet
+                handoff.offer(t)
+            } finally {
+                httpClient.close()
+            }
+        }
+        val signal = handoff.take()
+        if (signal is Throwable) throw this.unwrap(signal)
+        val meta = signal as StreamedResponse
+        val stream = CloseListenerInputStream(meta.body) {
+            closed.complete(Unit)
+            scope.cancel()
+        }
+        return HttpResponse(meta.url, meta.status, stream, meta.headers)
+    }
+
+    private fun buildClient(request: HttpRequest, cookieManager: CookieManager?): KtorClient {
         val follow = this.isFollowRedirects(request)
-        val connectTimeout = this.client.connectTimeout.toLong()
-        val readTimeout = this.client.readTimeout.toLong()
+        val connectTimeout = timeoutMillis(this.client.connectTimeout)
+        val readTimeout = timeoutMillis(this.client.readTimeout)
         val proxyHandler = this.client.proxyHandler
-        val clientConfig = this.clientConfig
+        val userConfig = this.clientConfig
         val configure: HttpClientConfig<*>.() -> Unit = {
             followRedirects = follow
             expectSuccess = false
@@ -112,13 +163,16 @@ class KtorExecutor @JvmOverloads constructor(
                 connectTimeoutMillis = connectTimeout
                 socketTimeoutMillis = readTimeout
             }
+            if (cookieManager != null) {
+                //Let Ktor manage cookies across redirects; the storage bridges to the shared CookieManager
+                install(HttpCookies) { storage = CookieManagerStorage(cookieManager) }
+            }
             if (proxyHandler.isProxySet) {
-                //The engine configuration is ignored by Ktor if a user provided client is used
                 engine {
                     proxy = proxyHandler.toJavaProxy()
                 }
             }
-            clientConfig?.invoke(this)
+            userConfig?.invoke(this)
         }
         return when {
             this.baseClient != null -> this.baseClient.config(configure)
@@ -127,30 +181,33 @@ class KtorExecutor @JvmOverloads constructor(
         }
     }
 
-    private fun buildRequest(request: HttpRequest, cookieManager: CookieManager?): HttpRequestBuilder {
+    private fun buildRequest(request: HttpRequest): HttpRequestBuilder {
         val builder = HttpRequestBuilder()
         builder.method = HttpMethod.parse(request.method)
         builder.url(request.getURL().toString())
+        //Cookies are handled by the HttpCookies plugin; content headers are set from the request body instead of the header map
+        val headers = this.getHeaders(request, null, false)
         if (request is HttpContentRequest && request.hasContent()) {
-            builder.setBody(this.toRequestBody(request.content!!, request.isStreamedRequest))
+            //Honor a user provided Content-Type header for the body (Ktor derives the sent Content-Type from the body)
+            val contentType = headers[CommonsHttpHeaders.CONTENT_TYPE.lowercase()]?.firstOrNull()
+            builder.setBody(this.toRequestBody(request.content!!, request.isStreamedRequest, contentType))
         }
-        //Content headers are excluded because Ktor does not allow setting them directly, they are taken from the request body instead
         this.setHeaders(
-            this.getHeaders(request, cookieManager, false),
+            headers.filterKeys { !it.equals(CommonsHttpHeaders.CONTENT_TYPE, true) && !it.equals(CommonsHttpHeaders.CONTENT_LENGTH, true) },
             { name, value -> builder.headers[name] = value },
             { name, value -> builder.headers.append(name, value) }
         )
         val proxyHandler = this.client.proxyHandler
         if (proxyHandler.isProxySet && proxyHandler.isAuthenticationSet && ProxyType.HTTP == proxyHandler.proxyType) {
             //Ktor has no built-in support for proxy authentication, sending the header preemptively works for HTTP proxies
-            val credentials = Base64.getEncoder().encodeToString("${proxyHandler.username}:${proxyHandler.password}".toByteArray(StandardCharsets.ISO_8859_1))
+            val credentials = Base64.getEncoder().encodeToString("${proxyHandler.username}:${proxyHandler.password}".toByteArray(Charsets.ISO_8859_1))
             builder.headers[HttpHeaders.ProxyAuthorization] = "Basic $credentials"
         }
         return builder
     }
 
-    private fun toRequestBody(content: HttpContent, streamed: Boolean): OutgoingContent {
-        val mediaType = ContentType.parse(content.type.toString())
+    private fun toRequestBody(content: HttpContent, streamed: Boolean, contentType: String?): OutgoingContent {
+        val mediaType = ContentType.parse(contentType ?: content.type.toString())
         return if (streamed) {
             object : OutgoingContent.WriteChannelContent() {
                 override val contentType: ContentType get() = mediaType
@@ -174,19 +231,57 @@ class KtorExecutor @JvmOverloads constructor(
         }
     }
 
-    private fun convertHeaders(headers: Headers): Map<String, List<String>> {
-        val map = HashMap<String, MutableList<String>>()
-        headers.forEach { name, values -> map.getOrPut(name) { ArrayList() }.addAll(values) }
-        return map
+    private fun timeoutMillis(value: Int): Long {
+        //A non-positive timeout means "infinite" for the other executors; Ktor rejects that value unless the infinite marker is used
+        return if (value <= 0) HttpTimeoutConfig.INFINITE_TIMEOUT_MS else value.toLong()
     }
 
     private fun unwrap(t: Throwable): IOException {
         var cause: Throwable? = t
         while (cause != null) {
             if (cause is IOException) return cause
+            if (cause is UncheckedIOException) return cause.cause ?: IOException(cause)
             cause = cause.cause
         }
         return IOException("Failed to execute request", t)
+    }
+
+    private class StreamedResponse(
+        val url: URL,
+        val status: Int,
+        val headers: Map<String, List<String>>,
+        val body: InputStream,
+    )
+
+    /**
+     * Bridges Ktor's cookie storage to a [CookieManager] so cookies are sent and stored per host across redirects.
+     */
+    private class CookieManagerStorage(private val cookieManager: CookieManager) : CookiesStorage {
+        override suspend fun get(requestUrl: Url): List<Cookie> {
+            val uri = URI(requestUrl.toString())
+            val headers = this.cookieManager.get(uri, emptyMap())
+            val cookies = ArrayList<Cookie>()
+            for ((name, values) in headers) {
+                if (!name.equals("Cookie", true)) continue
+                for (header in values) {
+                    for (pair in header.split(";")) {
+                        val trimmed = pair.trim()
+                        val idx = trimmed.indexOf('=')
+                        if (idx <= 0) continue
+                        cookies.add(Cookie(name = trimmed.substring(0, idx), value = trimmed.substring(idx + 1), encoding = CookieEncoding.RAW, domain = requestUrl.host, path = "/"))
+                    }
+                }
+            }
+            return cookies
+        }
+
+        override suspend fun addCookie(requestUrl: Url, cookie: Cookie) {
+            val uri = URI(requestUrl.toString())
+            this.cookieManager.put(uri, mapOf("Set-Cookie" to listOf(renderSetCookieHeader(cookie))))
+        }
+
+        override fun close() {
+        }
     }
 
 }

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/ExecutorCustomizationTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/ExecutorCustomizationTest.java
@@ -1,0 +1,100 @@
+package net.lenni0451.commons.httpclient;
+
+import net.lenni0451.commons.httpclient.constants.StatusCodes;
+import net.lenni0451.commons.httpclient.executor.HttpClientExecutor;
+import net.lenni0451.commons.httpclient.executor.URLConnectionExecutor;
+import net.lenni0451.commons.httpclient.executor.extra.OkHttpExecutor;
+import net.lenni0451.commons.httpclient.executor.extra.ReactorNettyExecutor;
+import net.lenni0451.commons.httpclient.server.TestWebServer;
+import okhttp3.OkHttpClient;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class ExecutorCustomizationTest {
+
+    private static TestWebServer server;
+    private static String baseUrl;
+
+    @BeforeAll
+    static void startServer() throws IOException {
+        server = new TestWebServer();
+        baseUrl = "http://127.0.0.1:" + server.bind();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.stop();
+    }
+
+    @Test
+    void urlConnectionCustomizer() throws IOException {
+        HttpClient client = new HttpClient(c -> new URLConnectionExecutor(c, connection -> connection.setRequestProperty("X-Custom", "url-connection")));
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("url-connection", response.getContent().getAsString());
+    }
+
+    @Test
+    void httpClientCustomizer() throws IOException {
+        HttpClient client = new HttpClient(c -> new HttpClientExecutor(c, builder -> builder.followRedirects(java.net.http.HttpClient.Redirect.NEVER)));
+        client.setFollowRedirects(true);
+        //The customizer is applied after the default configuration and overrides the client settings
+        HttpResponse response = client.get(baseUrl + "/redirect").execute();
+        assertEquals(StatusCodes.MOVED_PERMANENTLY, response.getStatusCode());
+    }
+
+    @Test
+    void httpClientCustomInstance() throws IOException {
+        java.net.http.HttpClient customClient = java.net.http.HttpClient.newBuilder().followRedirects(java.net.http.HttpClient.Redirect.NEVER).build();
+        HttpClient client = new HttpClient(c -> new HttpClientExecutor(c, customClient));
+        client.setFollowRedirects(true);
+        HttpResponse response = client.get(baseUrl + "/redirect").execute();
+        assertEquals(StatusCodes.MOVED_PERMANENTLY, response.getStatusCode());
+        //The user provided client must still be usable for further requests
+        response = client.get(baseUrl + "/constant").execute();
+        assertEquals("test", response.getContent().getAsString());
+    }
+
+    @Test
+    void okHttpCustomizer() throws IOException {
+        HttpClient client = new HttpClient(c -> new OkHttpExecutor(c, builder -> builder.addInterceptor(chain ->
+                chain.proceed(chain.request().newBuilder().header("X-Custom", "okhttp").build()))));
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("okhttp", response.getContent().getAsString());
+    }
+
+    @Test
+    void okHttpBaseInstance() throws IOException {
+        OkHttpClient baseClient = new OkHttpClient.Builder()
+                .addInterceptor(chain -> chain.proceed(chain.request().newBuilder().header("X-Custom", "okhttp-base").build()))
+                .build();
+        HttpClient client = new HttpClient(c -> new OkHttpExecutor(c, baseClient));
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("okhttp-base", response.getContent().getAsString());
+        //The dispatcher and connection pool of the user provided client must still be usable
+        response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("okhttp-base", response.getContent().getAsString());
+    }
+
+    @Test
+    void reactorNettyCustomizer() throws IOException {
+        HttpClient client = new HttpClient(c -> new ReactorNettyExecutor(c, httpClient ->
+                httpClient.headers(headers -> headers.set("X-Custom", "reactor"))));
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("reactor", response.getContent().getAsString());
+    }
+
+    @Test
+    void reactorNettyBaseInstance() throws IOException {
+        reactor.netty.http.client.HttpClient baseClient = reactor.netty.http.client.HttpClient.create()
+                .headers(headers -> headers.set("X-Custom", "reactor-base"));
+        HttpClient client = new HttpClient(c -> new ReactorNettyExecutor(c, baseClient));
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("reactor-base", response.getContent().getAsString());
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientExecutorTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientExecutorTest.java
@@ -1,0 +1,45 @@
+package net.lenni0451.commons.httpclient;
+
+import net.lenni0451.commons.httpclient.constants.StatusCodes;
+import net.lenni0451.commons.httpclient.executor.HttpClientExecutor;
+import net.lenni0451.commons.httpclient.server.TestWebServer;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+class HttpClientExecutorTest {
+
+    private static TestWebServer server;
+    private static String baseUrl;
+
+    @BeforeAll
+    static void startServer() throws IOException {
+        server = new TestWebServer();
+        baseUrl = "http://127.0.0.1:" + server.bind();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.stop();
+    }
+
+    @Test
+    void customClientCookiesRoundTrip() throws IOException {
+        //A user provided java.net.http client has no cookie handler, so cookies are applied per request via headers
+        java.net.http.HttpClient customClient = java.net.http.HttpClient.newHttpClient();
+        HttpClient client = new HttpClient(c -> new HttpClientExecutor(c, customClient));
+
+        HttpResponse first = client.get(baseUrl + "/cookieEcho").execute();
+        assertEquals(StatusCodes.OK, first.getStatusCode());
+        assertEquals("<none>", first.getContent().getAsString());
+
+        //The cookie set by the first response must be stored and sent on the second request
+        HttpResponse second = client.get(baseUrl + "/cookieEcho").execute();
+        assertEquals("session=abc123", second.getContent().getAsString());
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientTest.java
@@ -19,6 +19,9 @@ import org.junit.jupiter.params.provider.MethodSource;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Optional;
+import java.util.Random;
 
 import static net.lenni0451.commons.httpclient.HttpClientSource.DATA_SOURCE;
 import static org.junit.jupiter.api.Assertions.*;
@@ -170,6 +173,196 @@ class HttpClientTest {
                 .execute();
         assertEquals(StatusCodes.OK, response.getStatusCode());
         assertEquals("Hello World", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void testHead(final HttpClient client) throws IOException {
+        HttpResponse response = client.head(baseUrl + "/methodEcho").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals(Optional.of("HEAD"), response.getFirstHeader("X-Method"));
+        assertEquals("", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void testPut(final HttpClient client) throws IOException {
+        HttpResponse response = client.put(baseUrl + "/echo")
+                .setContent(new StringContent("put body"))
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("put body", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void testDelete(final HttpClient client) throws IOException {
+        HttpResponse response = client.delete(baseUrl + "/methodEcho").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("DELETE", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void multiValueRequestHeader(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Multi")
+                .appendHeader("X-Multi", "a")
+                .appendHeader("X-Multi", "b")
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        //Some clients send multiple header lines, some join the values with ", "
+        assertEquals("a,b", response.getContent().getAsString().replace(", ", ","));
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void multiValueResponseHeader(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/multiHeader").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        List<String> values = response.getHeader("X-Multi");
+        assertNotNull(values);
+        //The value order is not guaranteed by all clients
+        assertEquals(2, values.size());
+        assertTrue(values.contains("first"));
+        assertTrue(values.contains("second"));
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void clientHeaderAndRequestOverride(final HttpClient client) throws IOException {
+        client.setHeader("X-Custom", "client");
+        HttpResponse response = client.get(baseUrl + "/headerEcho?name=X-Custom").execute();
+        assertEquals("client", response.getContent().getAsString());
+
+        response = client.get(baseUrl + "/headerEcho?name=X-Custom")
+                .setHeader("X-Custom", "request")
+                .execute();
+        assertEquals("request", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void cookieRoundTrip(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/cookieEcho").execute();
+        assertEquals("<none>", response.getContent().getAsString());
+
+        response = client.get(baseUrl + "/cookieEcho").execute();
+        assertEquals("session=abc123", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void noCookieManager(final HttpClient client) throws IOException {
+        client.setCookieManager(null);
+        client.get(baseUrl + "/cookieEcho").execute();
+        HttpResponse response = client.get(baseUrl + "/cookieEcho").execute();
+        assertEquals("<none>", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void gzipDecodedContent(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/gzip").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("Hello Gzip", response.getDecodedContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void readTimeout(final HttpClient client) {
+        client.setReadTimeout(300);
+        assertThrows(IOException.class, () -> client.get(baseUrl + "/slow?delay=1500").execute());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void largeContent(final HttpClient client) throws IOException {
+        byte[] payload = new byte[256 * 1024];
+        new Random(42).nextBytes(payload);
+        HttpResponse response = client.post(baseUrl + "/echo")
+                .setContent(new ByteArrayContent(payload))
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertArrayEquals(payload, response.getContent().getAsBytes());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void largeContentStreamed(final HttpClient client) throws IOException {
+        byte[] payload = new byte[256 * 1024];
+        new Random(42).nextBytes(payload);
+        HttpResponse response = client.post(baseUrl + "/echo")
+                .setContent(HttpContent.inputStream(ContentTypes.APPLICATION_OCTET_STREAM, new ByteArrayInputStream(payload), payload.length))
+                .setStreamedRequest(true)
+                .setStreamedResponse(true)
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertArrayEquals(payload, response.getContent().getAsBytes());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void chunkedStreamedRequest(final HttpClient client) throws IOException {
+        byte[] payload = "chunked request".getBytes(StandardCharsets.UTF_8);
+        //The content length is unknown, forcing the executors to use chunked transfer encoding
+        HttpResponse response = client.post(baseUrl + "/echo")
+                .setContent(HttpContent.inputStream(ContentTypes.APPLICATION_OCTET_STREAM, new ByteArrayInputStream(payload), -1))
+                .setStreamedRequest(true)
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("chunked request", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void utf8Content(final HttpClient client) throws IOException {
+        String text = "Привет мир 🌍 üöä";
+        HttpResponse response = client.post(baseUrl + "/echo")
+                .setContent(new StringContent(text))
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals(text, response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void queryParameters(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/queryEcho?foo=bar&baz=qux").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("foo=bar&baz=qux", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void noContent204(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/noContent").execute();
+        assertEquals(StatusCodes.NO_CONTENT, response.getStatusCode());
+        assertEquals("", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void errorBodyPost(final HttpClient client) throws IOException {
+        HttpResponse response = client.post(baseUrl + "/response?content=error&code=500")
+                .setContent(new StringContent("ignored"))
+                .execute();
+        assertEquals(StatusCodes.INTERNAL_SERVER_ERROR, response.getStatusCode());
+        assertEquals("error", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void multiPartPost(final HttpClient client) throws IOException {
+        HttpResponse response = client.post(baseUrl + "/echo")
+                .setContent(HttpContent.multiPartForm()
+                        .addPart("field", HttpContent.string("Hello Part"))
+                        .addPart("file", HttpContent.bytes(new byte[]{1, 2, 3}), "data.bin"))
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        String body = response.getContent().getAsString();
+        assertTrue(body.contains("name=\"field\""));
+        assertTrue(body.contains("Hello Part"));
+        assertTrue(body.contains("filename=\"data.bin\""));
     }
 
 }

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/HttpClientTest.java
@@ -30,6 +30,12 @@ class HttpClientTest {
 
     private static TestWebServer server;
     private static String baseUrl;
+    //Deterministic payload shared across parameterized runs (Random with a fixed seed produces identical bytes)
+    private static final byte[] LARGE_PAYLOAD = new byte[256 * 1024];
+
+    static {
+        new Random(42).nextBytes(LARGE_PAYLOAD);
+    }
 
     @BeforeAll
     static void startServer() throws IOException {
@@ -277,8 +283,7 @@ class HttpClientTest {
     @ParameterizedTest
     @MethodSource(DATA_SOURCE)
     void largeContent(final HttpClient client) throws IOException {
-        byte[] payload = new byte[256 * 1024];
-        new Random(42).nextBytes(payload);
+        byte[] payload = LARGE_PAYLOAD;
         HttpResponse response = client.post(baseUrl + "/echo")
                 .setContent(new ByteArrayContent(payload))
                 .execute();
@@ -289,8 +294,7 @@ class HttpClientTest {
     @ParameterizedTest
     @MethodSource(DATA_SOURCE)
     void largeContentStreamed(final HttpClient client) throws IOException {
-        byte[] payload = new byte[256 * 1024];
-        new Random(42).nextBytes(payload);
+        byte[] payload = LARGE_PAYLOAD;
         HttpResponse response = client.post(baseUrl + "/echo")
                 .setContent(HttpContent.inputStream(ContentTypes.APPLICATION_OCTET_STREAM, new ByteArrayInputStream(payload), payload.length))
                 .setStreamedRequest(true)
@@ -348,6 +352,35 @@ class HttpClientTest {
                 .execute();
         assertEquals(StatusCodes.INTERNAL_SERVER_ERROR, response.getStatusCode());
         assertEquals("error", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void contentTypeOverride(final HttpClient client) throws IOException {
+        //A user provided Content-Type header must win over the content's own type on every backend
+        HttpResponse response = client.post(baseUrl + "/contentType")
+                .setContent(new StringContent("body"))
+                .setHeader("Content-Type", "application/vnd.custom+json")
+                .execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("application/vnd.custom+json", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void quotedCharsetContentType(final HttpClient client) throws IOException {
+        //A response with a quoted charset (legal per RFC 9110) must not crash the content type parser
+        HttpResponse response = client.get(baseUrl + "/quotedCharset").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("quoted", response.getContent().getAsString());
+    }
+
+    @ParameterizedTest
+    @MethodSource(DATA_SOURCE)
+    void quotedCharsetContentTypeStreamed(final HttpClient client) throws IOException {
+        HttpResponse response = client.get(baseUrl + "/quotedCharset").setStreamedResponse(true).execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertEquals("quoted", response.getContent().getAsString());
     }
 
     @ParameterizedTest

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/OkHttpExecutorTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/OkHttpExecutorTest.java
@@ -1,0 +1,74 @@
+package net.lenni0451.commons.httpclient;
+
+import net.lenni0451.commons.httpclient.constants.StatusCodes;
+import net.lenni0451.commons.httpclient.content.impl.StringContent;
+import net.lenni0451.commons.httpclient.executor.extra.OkHttpExecutor;
+import net.lenni0451.commons.httpclient.server.TestWebServer;
+import okhttp3.Dispatcher;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OkHttpExecutorTest {
+
+    private static TestWebServer server;
+    private static String baseUrl;
+
+    @BeforeAll
+    static void startServer() throws IOException {
+        server = new TestWebServer();
+        baseUrl = "http://127.0.0.1:" + server.bind();
+    }
+
+    @AfterAll
+    static void stopServer() {
+        server.stop();
+    }
+
+    private static HttpClient client() {
+        return new HttpClient(OkHttpExecutor::new);
+    }
+
+    @Test
+    void getWithBodyThrowsIOException() {
+        //OkHttp rejects a body on GET with an unchecked exception; it must be wrapped in an IOException
+        assertThrows(IOException.class, () -> client().contentRequest("GET", baseUrl + "/echo")
+                .setContent(new StringContent("body"))
+                .execute());
+    }
+
+    @Test
+    void nonAsciiHeaderThrowsIOException() {
+        //OkHttp rejects non-ASCII header values with an unchecked exception; it must be wrapped in an IOException
+        assertThrows(IOException.class, () -> client().get(baseUrl + "/echo")
+                .setHeader("X-Info", "münchen")
+                .execute());
+    }
+
+    @Test
+    void redirectCookiePreserved() throws IOException {
+        //A cookie set on the redirect hop must be stored and sent to the redirect target (handled by the cookie jar)
+        HttpResponse response = client().get(baseUrl + "/redirectCookie").execute();
+        assertEquals(StatusCodes.OK, response.getStatusCode());
+        assertTrue(response.getContent().getAsString().contains("rc=1"));
+    }
+
+    @Test
+    void customizerInjectedDispatcherIsNotShutDown() throws IOException {
+        Dispatcher shared = new Dispatcher();
+        HttpClient client = new HttpClient(c -> new OkHttpExecutor(c, builder -> builder.dispatcher(shared)));
+        client.get(baseUrl + "/constant").execute();
+        //The executor must not shut down a dispatcher it does not own
+        assertFalse(shared.executorService().isShutdown());
+        //Subsequent requests must keep working
+        assertEquals("test", client.get(baseUrl + "/constant").execute().getContent().getAsString());
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/CookieEchoHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/CookieEchoHandler.java
@@ -1,0 +1,23 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class CookieEchoHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        List<String> cookies = exchange.getRequestHeaders().get("Cookie");
+        String response = cookies == null ? "<none>" : String.join("; ", cookies);
+        exchange.getResponseHeaders().add("Set-Cookie", "session=abc123");
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/GzipHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/GzipHandler.java
@@ -11,14 +11,23 @@ import java.util.zip.GZIPOutputStream;
 public class GzipHandler implements HttpHandler {
 
     public static final String CONTENT = "Hello Gzip";
+    private static final byte[] COMPRESSED;
+
+    static {
+        try {
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+                gzip.write(CONTENT.getBytes(StandardCharsets.UTF_8));
+            }
+            COMPRESSED = baos.toByteArray();
+        } catch (IOException e) {
+            throw new ExceptionInInitializerError(e);
+        }
+    }
 
     @Override
     public void handle(HttpExchange exchange) throws IOException {
-        ByteArrayOutputStream baos = new ByteArrayOutputStream();
-        try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
-            gzip.write(CONTENT.getBytes(StandardCharsets.UTF_8));
-        }
-        byte[] compressed = baos.toByteArray();
+        byte[] compressed = COMPRESSED;
         exchange.getResponseHeaders().add("Content-Encoding", "gzip");
         exchange.sendResponseHeaders(200, compressed.length);
         exchange.getResponseBody().write(compressed);

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/GzipHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/GzipHandler.java
@@ -1,0 +1,28 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
+
+public class GzipHandler implements HttpHandler {
+
+    public static final String CONTENT = "Hello Gzip";
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        try (GZIPOutputStream gzip = new GZIPOutputStream(baos)) {
+            gzip.write(CONTENT.getBytes(StandardCharsets.UTF_8));
+        }
+        byte[] compressed = baos.toByteArray();
+        exchange.getResponseHeaders().add("Content-Encoding", "gzip");
+        exchange.sendResponseHeaders(200, compressed.length);
+        exchange.getResponseBody().write(compressed);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/HeaderEchoHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/HeaderEchoHandler.java
@@ -1,0 +1,24 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import net.lenni0451.commons.httpclient.utils.URLWrapper;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+public class HeaderEchoHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String name = new URLWrapper(exchange.getRequestURI()).wrapQueryParameters().getFirstValue("name").orElse("");
+        List<String> values = exchange.getRequestHeaders().get(name);
+        String response = values == null ? "<none>" : String.join(",", values);
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/MethodEchoHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/MethodEchoHandler.java
@@ -1,0 +1,25 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class MethodEchoHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String method = exchange.getRequestMethod();
+        exchange.getResponseHeaders().add("X-Method", method);
+        if ("HEAD".equals(method)) {
+            exchange.sendResponseHeaders(200, -1);
+        } else {
+            byte[] bytes = method.getBytes(StandardCharsets.UTF_8);
+            exchange.sendResponseHeaders(200, bytes.length);
+            exchange.getResponseBody().write(bytes);
+        }
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/MultiHeaderHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/MultiHeaderHandler.java
@@ -1,0 +1,19 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+
+public class MultiHeaderHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        exchange.getResponseHeaders().add("X-Multi", "first");
+        exchange.getResponseHeaders().add("X-Multi", "second");
+        exchange.sendResponseHeaders(200, 2);
+        exchange.getResponseBody().write("ok".getBytes());
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/NoContentHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/NoContentHandler.java
@@ -1,0 +1,16 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+
+public class NoContentHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        exchange.sendResponseHeaders(204, -1);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/QueryEchoHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/QueryEchoHandler.java
@@ -1,0 +1,21 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class QueryEchoHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        String query = exchange.getRequestURI().getRawQuery();
+        String response = query == null ? "<none>" : query;
+        byte[] bytes = response.getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/QuotedCharsetHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/QuotedCharsetHandler.java
@@ -1,0 +1,21 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+public class QuotedCharsetHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        //A quoted charset is legal per RFC 9110 and must not crash the content type parser
+        exchange.getResponseHeaders().add("Content-Type", "text/plain; charset=\"utf-8\"");
+        byte[] bytes = "quoted".getBytes(StandardCharsets.UTF_8);
+        exchange.sendResponseHeaders(200, bytes.length);
+        exchange.getResponseBody().write(bytes);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/RedirectCookieHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/RedirectCookieHandler.java
@@ -1,0 +1,20 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import net.lenni0451.commons.httpclient.constants.StatusCodes;
+
+import java.io.IOException;
+
+public class RedirectCookieHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        //Set a cookie on the redirect hop itself; it must be stored and sent to the redirect target
+        exchange.getResponseHeaders().add("Set-Cookie", "rc=1");
+        exchange.getResponseHeaders().add("Location", "/cookieEcho");
+        exchange.sendResponseHeaders(StatusCodes.MOVED_PERMANENTLY, -1);
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/SlowHandler.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/SlowHandler.java
@@ -1,0 +1,24 @@
+package net.lenni0451.commons.httpclient.server;
+
+import com.sun.net.httpserver.HttpExchange;
+import com.sun.net.httpserver.HttpHandler;
+import net.lenni0451.commons.httpclient.utils.URLWrapper;
+
+import java.io.IOException;
+
+public class SlowHandler implements HttpHandler {
+
+    @Override
+    public void handle(HttpExchange exchange) throws IOException {
+        long delay = new URLWrapper(exchange.getRequestURI()).wrapQueryParameters().getFirstValue("delay").map(Long::parseLong).orElse(1000L);
+        try {
+            Thread.sleep(delay);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+        exchange.sendResponseHeaders(200, 4);
+        exchange.getResponseBody().write("slow".getBytes());
+        exchange.close();
+    }
+
+}

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/TestWebServer.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/TestWebServer.java
@@ -5,13 +5,17 @@ import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.ServerSocket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class TestWebServer {
 
     private final HttpServer server;
+    private final ExecutorService executor = Executors.newCachedThreadPool();
 
     public TestWebServer() throws IOException {
         this.server = HttpServer.create();
+        this.server.setExecutor(this.executor);
 
         this.server.createContext("/echo", new ContentEchoHandler());
         this.server.createContext("/response", new ContentResponseHandler());
@@ -20,6 +24,14 @@ public class TestWebServer {
         this.server.createContext("/contentType", new ContentTypeEchoHandler());
         this.server.createContext("/redirect", new RedirectHandler());
         this.server.createContext("/constant", new ConstantContentHandler());
+        this.server.createContext("/headerEcho", new HeaderEchoHandler());
+        this.server.createContext("/multiHeader", new MultiHeaderHandler());
+        this.server.createContext("/gzip", new GzipHandler());
+        this.server.createContext("/slow", new SlowHandler());
+        this.server.createContext("/cookieEcho", new CookieEchoHandler());
+        this.server.createContext("/methodEcho", new MethodEchoHandler());
+        this.server.createContext("/queryEcho", new QueryEchoHandler());
+        this.server.createContext("/noContent", new NoContentHandler());
     }
 
     public int bind() throws IOException {
@@ -34,6 +46,7 @@ public class TestWebServer {
 
     public void stop() {
         this.server.stop(0);
+        this.executor.shutdownNow();
     }
 
 }

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/TestWebServer.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/server/TestWebServer.java
@@ -32,6 +32,8 @@ public class TestWebServer {
         this.server.createContext("/methodEcho", new MethodEchoHandler());
         this.server.createContext("/queryEcho", new QueryEchoHandler());
         this.server.createContext("/noContent", new NoContentHandler());
+        this.server.createContext("/quotedCharset", new QuotedCharsetHandler());
+        this.server.createContext("/redirectCookie", new RedirectCookieHandler());
     }
 
     public int bind() throws IOException {

--- a/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/utils/stream/CloseListenerInputStreamTest.java
+++ b/commons-httpclient/src/test/java/net/lenni0451/commons/httpclient/utils/stream/CloseListenerInputStreamTest.java
@@ -1,0 +1,34 @@
+package net.lenni0451.commons.httpclient.utils.stream;
+
+import org.junit.jupiter.api.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CloseListenerInputStreamTest {
+
+    @Test
+    void listenerRunsWhenWrappedCloseThrows() {
+        boolean[] listenerRan = {false};
+        InputStream throwing = new InputStream() {
+            @Override
+            public int read() {
+                return -1;
+            }
+
+            @Override
+            public void close() throws IOException {
+                throw new IOException("close failed");
+            }
+        };
+        CloseListenerInputStream stream = new CloseListenerInputStream(throwing, () -> listenerRan[0] = true);
+
+        //Closing must still surface the wrapped stream's error, but the listener must run so backend resources are released
+        assertThrows(IOException.class, stream::close);
+        assertTrue(listenerRan[0]);
+    }
+
+}

--- a/commons-httpclient/src/test/kotlin/net/lenni0451/commons/httpclient/KtorExecutorTest.kt
+++ b/commons-httpclient/src/test/kotlin/net/lenni0451/commons/httpclient/KtorExecutorTest.kt
@@ -1,0 +1,67 @@
+package net.lenni0451.commons.httpclient
+
+import io.ktor.client.engine.cio.CIO
+import io.ktor.client.plugins.defaultRequest
+import io.ktor.client.request.header
+import net.lenni0451.commons.httpclient.executor.extra.KtorExecutor
+import net.lenni0451.commons.httpclient.server.TestWebServer
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.Test
+import io.ktor.client.HttpClient as KtorClient
+
+class KtorExecutorTest {
+
+    companion object {
+        private lateinit var server: TestWebServer
+        private lateinit var baseUrl: String
+
+        @JvmStatic
+        @BeforeAll
+        fun startServer() {
+            server = TestWebServer()
+            baseUrl = "http://127.0.0.1:" + server.bind()
+        }
+
+        @JvmStatic
+        @AfterAll
+        fun stopServer() {
+            server.stop()
+        }
+    }
+
+    @Test
+    fun engineFactory() {
+        val client = HttpClient { c -> KtorExecutor(c, engineFactory = CIO) }
+        val response = client.get("$baseUrl/constant").execute()
+        assertEquals("test", response.content.asString)
+    }
+
+    @Test
+    fun clientConfig() {
+        val client = HttpClient { c ->
+            KtorExecutor(c, clientConfig = {
+                defaultRequest { header("X-Custom", "ktor-config") }
+            })
+        }
+        val response = client.get("$baseUrl/headerEcho?name=X-Custom").execute()
+        assertEquals("ktor-config", response.content.asString)
+    }
+
+    @Test
+    fun baseClient() {
+        val baseClient = KtorClient {
+            defaultRequest { header("X-Custom", "ktor-base") }
+        }
+        try {
+            val client = HttpClient { c -> KtorExecutor(c, baseClient = baseClient) }
+            assertEquals("ktor-base", client.get("$baseUrl/headerEcho?name=X-Custom").execute().content.asString)
+            //The engine of the user provided client must still be usable for further requests
+            assertEquals("ktor-base", client.get("$baseUrl/headerEcho?name=X-Custom").execute().content.asString)
+        } finally {
+            baseClient.close()
+        }
+    }
+
+}

--- a/commons-httpclient/src/test/kotlin/net/lenni0451/commons/httpclient/KtorExecutorTest.kt
+++ b/commons-httpclient/src/test/kotlin/net/lenni0451/commons/httpclient/KtorExecutorTest.kt
@@ -1,14 +1,22 @@
 package net.lenni0451.commons.httpclient
 
+import com.sun.net.httpserver.HttpServer
 import io.ktor.client.engine.cio.CIO
 import io.ktor.client.plugins.defaultRequest
 import io.ktor.client.request.header
 import net.lenni0451.commons.httpclient.executor.extra.KtorExecutor
+import net.lenni0451.commons.httpclient.proxy.ProxyType
 import net.lenni0451.commons.httpclient.server.TestWebServer
 import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertThrows
+import org.junit.jupiter.api.Assertions.assertTrue
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Timeout
+import java.net.InetSocketAddress
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
 import io.ktor.client.HttpClient as KtorClient
 
 class KtorExecutorTest {
@@ -47,6 +55,73 @@ class KtorExecutorTest {
         }
         val response = client.get("$baseUrl/headerEcho?name=X-Custom").execute()
         assertEquals("ktor-config", response.content.asString)
+    }
+
+    @Test
+    fun zeroReadTimeout() {
+        //A read timeout of 0 (meaning infinite) must not crash the Ktor timeout plugin
+        val client = HttpClient { c -> KtorExecutor(c, engineFactory = CIO) }
+        client.readTimeout = 0
+        client.connectTimeout = 0
+        assertEquals("test", client.get("$baseUrl/constant").execute().content.asString)
+    }
+
+    @Test
+    @Timeout(15)
+    fun incrementalStreaming() {
+        //execute() must return before the whole body arrives, proving the streamed response is not buffered in memory
+        val latch = CountDownLatch(1)
+        val server = HttpServer.create(InetSocketAddress("127.0.0.1", 0), 0)
+        server.createContext("/stream") { exchange ->
+            exchange.sendResponseHeaders(200, 0)
+            val os = exchange.responseBody
+            os.write("hello".toByteArray())
+            os.flush()
+            latch.await()
+            os.close()
+            exchange.close()
+        }
+        server.executor = Executors.newSingleThreadExecutor()
+        server.start()
+        try {
+            val client = HttpClient { c -> KtorExecutor(c, engineFactory = CIO) }
+            client.readTimeout = 10000
+            val response = client.get("http://127.0.0.1:${server.address.port}/stream").setStreamedResponse(true).execute()
+            val stream = response.content.asStream
+            val buffer = ByteArray(5)
+            var read = 0
+            while (read < 5) {
+                val r = stream.read(buffer, read, 5 - read)
+                if (r < 0) break
+                read += r
+            }
+            assertEquals("hello", String(buffer, 0, read))
+            stream.close()
+        } finally {
+            latch.countDown()
+            server.stop(0)
+        }
+    }
+
+    @Test
+    fun redirectCookiePreserved() {
+        //A cookie set on the redirect hop must be stored and sent to the redirect target (handled by the HttpCookies plugin)
+        val client = HttpClient { c -> KtorExecutor(c, engineFactory = CIO) }
+        val body = client.get("$baseUrl/redirectCookie").execute().content.asString
+        assertTrue(body.contains("rc=1"))
+    }
+
+    @Test
+    fun proxyWithBaseClientThrows() {
+        //A proxy can not be applied to a user provided client, so the executor must fail loudly instead of bypassing it
+        val baseClient = KtorClient {}
+        try {
+            val client = HttpClient { c -> KtorExecutor(c, baseClient = baseClient) }
+            client.proxyHandler.setProxy(ProxyType.HTTP, "127.0.0.1", 1)
+            assertThrows(UnsupportedOperationException::class.java) { client.get("$baseUrl/constant").execute() }
+        } finally {
+            baseClient.close()
+        }
     }
 
     @Test

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,7 @@
 [versions]
 asm = "9.10.1"
+kotlin = "2.4.0"
+ktor = "3.5.1"
 
 [libraries]
 findbugs = { module = "com.google.code.findbugs:jsr305", version = "3.0.2" }
@@ -8,6 +10,10 @@ lombok = { module = "org.projectlombok:lombok", version = "1.18.46" }
 brigadier = { module = "com.mojang:brigadier", version = "1.3.10" }
 gson = { module = "com.google.code.gson:gson", version = "2.14.0" }
 reactorNetty = { module = "io.projectreactor.netty:reactor-netty-http", version = "1.3.6" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version = "4.12.0" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin" }
+ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }
+ktor-client-cio = { module = "io.ktor:ktor-client-cio", version.ref = "ktor" }
 slf4j = { module = "org.slf4j:slf4j-api", version = "2.0.18" }
 
 junit-bom = { module = "org.junit:junit-bom", version = "5.14.4" }
@@ -29,3 +35,4 @@ netty = ["netty", "netty-raknet", "netty-kcp"]
 
 [plugins]
 templateProcessor = { id = "net.lenni0451.template-processor", version = "1.0.1" }
+kotlinJvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }


### PR DESCRIPTION
## Summary

Adds two new optional `RequestExecutor` backends to `commons-httpclient` and lets users customize the underlying HTTP client of every backend.

- **OkHttp** executor (`OkHttpExecutor`)
- **Ktor** executor (`KtorExecutor`, written in Kotlin)
- **Backend customization** — every executor (`URLConnection`, Java 11 `HttpClient`, reactor-netty, OkHttp, Ktor) accepts a user-provided client instance and/or a customizer hook via new constructors, used together with `new HttpClient(c -> new XyzExecutor(c, ...))`.

All new dependencies are `compileOnly` and stay out of the published POM — projects that don't use OkHttp/Ktor pull in nothing. `ExecutorType` gains `OK_HTTP` and `KTOR`, discovered by reflection like the existing ones.

> **Heads-up on Kotlin:** the Ktor executor is Kotlin, so this adds the Kotlin Gradle plugin and a `kotlin` source set to `commons-httpclient` (with `kotlin.stdlib.default.dependency=false` so the stdlib is not forced onto consumers). If you'd rather not take Kotlin into the build, the OkHttp backend, the customization API and the bug fixes below are all independent of it and can be cherry-picked without the Ktor commit.

## Bug fixes (also cover the existing backends)

- `ContentType.parse` tolerates quoted/malformed charset values (e.g. `charset="utf-8"`, legal per RFC 9110) instead of throwing `IllegalCharsetNameException` — this previously crashed response parsing on **every** backend.
- `CloseListenerInputStream.close()` always runs its listener, even if closing the wrapped stream throws, so backend resources are released.
- OkHttp/Ktor honor a user-provided `Content-Type` header for the request body.
- OkHttp wraps `IllegalArgumentException` (body on GET/HEAD, non-ASCII header values) in `IOException` to keep the `RequestExecutor` contract.
- OkHttp reuses a single backing client (shared, kept-alive connection pool/dispatcher) and no longer shuts down resources injected via a customizer.
- OkHttp/Ktor manage cookies across redirects (OkHttp `CookieJar` / Ktor `HttpCookies`), bridged to the client's `CookieManager`.
- Ktor streams responses incrementally instead of buffering the whole body in memory.
- Ktor maps a `0` timeout to the infinite marker instead of crashing, throws when a proxy is combined with a user-provided client (instead of silently bypassing it and leaking `Proxy-Authorization`), and wraps engine-discovery failures in `IOException`.
- Java 11 executor applies cookies per request when a user-provided client is used.

## Tests

`HttpClientTest` is parameterized across all available executors; new cases cover HEAD/PUT/DELETE, multi-value headers, cookies, gzip, read timeouts, large/chunked/UTF-8 bodies, multipart, 204/error responses, quoted-charset content types and Content-Type overrides. Backend-specific tests (`OkHttpExecutorTest`, `KtorExecutorTest`, `HttpClientExecutorTest`, `CloseListenerInputStreamTest`, `ExecutorCustomizationTest`) cover the fixes above. Full module build (checkstyle, javadoc, jar) is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
